### PR TITLE
jsonrpc2: code response-marshaling failures as InternalError + test hardening

### DIFF
--- a/channel_stream_test.go
+++ b/channel_stream_test.go
@@ -62,8 +62,9 @@ func TestChannelStreamCloseUnblocksWrite(t *testing.T) {
 	a, b := NewChannelStreamPair(0)
 	defer b.Close()
 	writeDone := make(chan error, 1)
+	ctx := t.Context()
 	go func() {
-		_, err := a.(frameStream).WriteFrame(context.Background(), []byte(`{"jsonrpc":"2.0","method":"blocked"}`))
+		_, err := a.(frameStream).WriteFrame(ctx, []byte(`{"jsonrpc":"2.0","method":"blocked"}`))
 		writeDone <- err
 	}()
 
@@ -90,8 +91,9 @@ func TestChannelStreamCloseUnblocksRead(t *testing.T) {
 	a, b := NewChannelStreamPair(0)
 	defer a.Close()
 	readDone := make(chan error, 1)
+	ctx := t.Context()
 	go func() {
-		_, _, err := a.(frameStream).ReadFrame(context.Background())
+		_, _, err := a.(frameStream).ReadFrame(ctx)
 		readDone <- err
 	}()
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -803,12 +803,12 @@ func TestCloseRacesConcurrentWrites(t *testing.T) {
 
 func TestConnReadNextDirectUnmarshalResult(t *testing.T) {
 	ctx := t.Context()
-	frame := []byte(`{"jsonrpc":"2.0","id":7,"result":{"ok":true}}`)
+	frame := []byte(`{"jsonrpc":"2.0","id":7,"result":{"val":"hello"}}`)
 	stream := &singleFrameStream{frame: frame}
 	c := &conn{stream: stream, codec: DefaultCodec, done: make(chan struct{})}
 
 	var got struct {
-		OK bool `json:"ok"`
+		Val string `json:"val"`
 	}
 	w := getWaiter(&got)
 	c.state.outgoingCalls.Add(NewNumberID(7), w)
@@ -832,8 +832,8 @@ func TestConnReadNextDirectUnmarshalResult(t *testing.T) {
 	if !w.resultReady {
 		t.Fatal("waiter resultReady = false, want true")
 	}
-	if !got.OK {
-		t.Fatalf("direct-unmarshaled result OK = false, want true")
+	if got.Val != "hello" {
+		t.Fatalf("direct-unmarshaled result Val = %q, want %q", got.Val, "hello")
 	}
 
 	// Evidence for direct-unmarshal safety on the numeric fast path (used by Conn
@@ -844,8 +844,8 @@ func TestConnReadNextDirectUnmarshalResult(t *testing.T) {
 	for i := range frame {
 		frame[i] = 'X'
 	}
-	if !got.OK {
-		t.Fatalf("direct-unmarshaled result corrupted after frame reuse simulation")
+	if got.Val != "hello" {
+		t.Fatalf("direct-unmarshaled result corrupted after frame reuse simulation: got %q", got.Val)
 	}
 
 	if c.state.outgoingCalls.Len() != 0 {

--- a/conn_test.go
+++ b/conn_test.go
@@ -761,7 +761,7 @@ func TestCloseRacesConcurrentWrites(t *testing.T) {
 		ea, eb := memTransport(NewNDJSONStream)(t)
 		client := NewConn(ea.stream)
 		server := NewConn(eb.stream)
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		client.Go(ctx, MethodNotFoundHandler)
 		server.Go(ctx, func(ctx context.Context, reply Replier, req Request) error {
 			return reply(ctx, nil, nil)
@@ -802,7 +802,7 @@ func TestCloseRacesConcurrentWrites(t *testing.T) {
 }
 
 func TestConnReadNextDirectUnmarshalResult(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	frame := []byte(`{"jsonrpc":"2.0","id":7,"result":{"ok":true}}`)
 	stream := &singleFrameStream{frame: frame}
 	c := &conn{stream: stream, codec: DefaultCodec, done: make(chan struct{})}
@@ -835,6 +835,19 @@ func TestConnReadNextDirectUnmarshalResult(t *testing.T) {
 	if !got.OK {
 		t.Fatalf("direct-unmarshaled result OK = false, want true")
 	}
+
+	// Evidence for direct-unmarshal safety on the numeric fast path (used by Conn
+	// for small responses): the result bytes from the frame were unmarshaled into
+	// user memory. Simulate the stream reusing its read buffer for the next frame
+	// (as headerStream/ndjsonStream do); the previously unmarshaled value must
+	// remain valid and not observe mutation.
+	for i := range frame {
+		frame[i] = 'X'
+	}
+	if !got.OK {
+		t.Fatalf("direct-unmarshaled result corrupted after frame reuse simulation")
+	}
+
 	if c.state.outgoingCalls.Len() != 0 {
 		t.Fatalf("outgoing calls len = %d, want 0", c.state.outgoingCalls.Len())
 	}
@@ -842,7 +855,7 @@ func TestConnReadNextDirectUnmarshalResult(t *testing.T) {
 }
 
 func TestConnReadNextDirectUnmarshalSkipsLargeResult(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	large := strings.Repeat("x", maxConnDirectUnmarshalResult+1)
 	frame := []byte(`{"jsonrpc":"2.0","id":9,"result":"` + large + `"}`)
 	stream := &singleFrameStream{frame: frame}

--- a/conn_test.go
+++ b/conn_test.go
@@ -163,7 +163,7 @@ func TestCallRoundTrip(t *testing.T) {
 				"error: handler reply marshaling failure": {
 					method:  "marshal-fail",
 					params:  nil,
-					wantErr: NewError(0, ""),
+					wantErr: NewError(InternalError, ""),
 				},
 			}
 			for tn, tt := range tests {

--- a/dispatch.go
+++ b/dispatch.go
@@ -211,7 +211,7 @@ func (c *conn) sendResponse(ctx context.Context, id ID, bc *batchCollector, resu
 	if err == nil {
 		raw, merr := marshalParams(c.codec, result)
 		if merr != nil {
-			resp.err = fmt.Errorf("jsonrpc2: marshaling response result: %w", Errorf(InternalError, "%v", merr))
+			resp.err = Errorf(InternalError, "jsonrpc2: marshaling response result: %v", merr)
 		} else {
 			resp.result = raw
 		}

--- a/dispatch.go
+++ b/dispatch.go
@@ -211,7 +211,7 @@ func (c *conn) sendResponse(ctx context.Context, id ID, bc *batchCollector, resu
 	if err == nil {
 		raw, merr := marshalParams(c.codec, result)
 		if merr != nil {
-			resp.err = fmt.Errorf("jsonrpc2: marshaling response result: %w", merr)
+			resp.err = fmt.Errorf("jsonrpc2: marshaling response result: %w", Errorf(InternalError, "%v", merr))
 		} else {
 			resp.result = raw
 		}

--- a/errors.go
+++ b/errors.go
@@ -20,8 +20,9 @@ type Error struct {
 	Message string `json:"message"`
 
 	// Data is an optional primitive or structured value that carries additional
-	// information about the error. It is omitted from the wire form when nil.
-	Data RawMessage `json:"data,omitempty"`
+	// information about the error. It is omitted from the wire form when the
+	// zero value.
+	Data RawMessage `json:"data,omitzero"`
 
 	// Code is a number indicating the error type that occurred.
 	Code Code `json:"code"`

--- a/framer_test.go
+++ b/framer_test.go
@@ -649,7 +649,7 @@ func benchmarkFramerRoundTrip(b *testing.B, framer Framer) {
 	b.Helper()
 	conn := &bufConn{}
 	s := framer(conn)
-	ctx := context.Background()
+	ctx := b.Context()
 	msg := NewCall(NewNumberID(1), "textDocument/hover", RawMessage(`{"line":10,"character":4}`))
 
 	b.ReportAllocs()

--- a/pipeline_client_test.go
+++ b/pipeline_client_test.go
@@ -257,7 +257,7 @@ func TestPipelineClientQueuedCanceledCallDelivers(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
-	err := client.writeQueuedCallFrames(context.Background(), []pipelineQueuedCall{{
+	err := client.writeQueuedCallFrames(t.Context(), []pipelineQueuedCall{{
 		ctx:    ctx,
 		id:     1,
 		method: "void",

--- a/runtime_modes_test.go
+++ b/runtime_modes_test.go
@@ -351,7 +351,7 @@ func TestBatchClientRawFrame(t *testing.T) {
 	readc := make(chan []byte, 1)
 	errc := make(chan error, 1)
 	go func() {
-		frame, _, err := serverStream.(frameStream).ReadFrame(context.Background())
+		frame, _, err := serverStream.(frameStream).ReadFrame(t.Context())
 		if err != nil {
 			errc <- err
 			return

--- a/syncclient_test.go
+++ b/syncclient_test.go
@@ -25,7 +25,7 @@ func syncClientServer(t *testing.T, framer Framer) (*SyncClient, func()) {
 		t.Fatalf("NewSyncClient: %v", err)
 	}
 	server := NewConn(framer(cb))
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx := t.Context()
 	server.Go(ctx, func(ctx context.Context, reply Replier, req Request) error {
 		switch req.Method() {
 		case "echo":
@@ -37,7 +37,6 @@ func syncClientServer(t *testing.T, framer Framer) (*SyncClient, func()) {
 		}
 	})
 	cleanup := func() {
-		cancel()
 		_ = client.Close()
 		_ = server.Close()
 		<-server.Done()
@@ -117,7 +116,7 @@ func TestSyncClientNotifyThenCall(t *testing.T) {
 	notes.Add(1)
 	var seen string
 	var seenMu sync.Mutex
-	serverCtx, cancel := context.WithCancel(context.Background())
+	serverCtx := t.Context()
 	server.Go(serverCtx, func(ctx context.Context, reply Replier, req Request) error {
 		if req.Method() == "note" {
 			seenMu.Lock()
@@ -129,7 +128,6 @@ func TestSyncClientNotifyThenCall(t *testing.T) {
 		return reply(ctx, nil, nil)
 	})
 	defer func() {
-		cancel()
 		_ = client.Close()
 		_ = server.Close()
 		<-server.Done()
@@ -176,13 +174,12 @@ func TestSyncClientEquivalentToConn(t *testing.T) {
 	ca, cb := net.Pipe()
 	cc := NewConn(NewNDJSONStream(ca))
 	server := NewConn(NewNDJSONStream(cb))
-	connCtx, cancel := context.WithCancel(context.Background())
+	connCtx := t.Context()
 	cc.Go(connCtx, MethodNotFoundHandler)
 	server.Go(connCtx, func(ctx context.Context, reply Replier, req Request) error {
 		return reply(ctx, raw(`{"got":`+string(orNull(req.Params()))+`}`), nil)
 	})
 	defer func() {
-		cancel()
 		_ = cc.Close()
 		<-cc.Done()
 		_ = server.Close()


### PR DESCRIPTION
## Summary

This branch lands two small but spec-relevant correctness fixes in the response path, a mandatory JSON-tag migration, and a round of test hardening/modernization.

### Production fixes

- **`dispatch.go` — code a server-side marshaling failure as `InternalError` (-32603).** When marshaling a handler's response `result` fails, the error is now wrapped in a typed `*Error` via `Errorf(InternalError, ...)` instead of a plain `fmt.Errorf`. Previously the failure surfaced with an uncoded `0`, which is not a valid JSON-RPC error code; a client doing `errors.As(err, &jsonrpc2.Error{})` and switching on `.Code` would mis-handle it. The typed construction preserves the error *code* context that `errors.As` needs (it intentionally interpolates with `%v`, not `%w`).
- **`errors.go` — `Error.Data` uses `omitzero` instead of `omitempty`.** Aligns with the project's json-experiment tag rules; the doc comment now describes zero-value omission.

### Tests

- **`conn_test.go` — strengthen the direct-unmarshal aliasing test.** `TestConnReadNextDirectUnmarshalResult` now unmarshals into a `string` (heap-backed) instead of a `bool` (copied by value), and then overwrites the source frame bytes and re-asserts. This actually proves the numeric response fast path *owns* its decoded data and does not alias the stream's read buffer — the bool variant could never have caught a leak.
- Update the matching expected error in `TestCallRoundTrip` to `NewError(InternalError, "")`.
- **Modernize test contexts** across `channel_stream_test.go`, `conn_test.go`, `framer_test.go`, `pipeline_client_test.go`, `runtime_modes_test.go`, and `syncclient_test.go`: replace `context.Background()` / `context.WithCancel(context.Background())` with `t.Context()` / `b.Context()`, removing now-redundant manual cancels.

## Verification

```
go build ./...   -> BUILD_OK
go vet ./...     -> VET_OK
go test ./...    -> ok (all packages)
```

## Notes

No public API changes. The wire-level behavior change is limited to the error *code* now sent on a response-marshaling failure (`0` -> `-32603`), which is the spec-correct value.
