### PR TITLE
make jsonrpc2 dispatch zero-allocation

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -48,9 +48,9 @@ func TestWithCodec(t *testing.T) {
 	server := jsonrpc2.NewConn(jsonrpc2.NewNDJSONStream(cb))
 
 	client.Go(ctx, jsonrpc2.MethodNotFoundHandler)
-	server.Go(ctx, func(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+	server.Go(ctx, func(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 		// Echo the params straight back as the result.
-		return reply(ctx, req.Params(), nil)
+		return jsonrpc2.RawMessage(string(req.Params())), nil
 	})
 	defer func() {
 		_ = client.Close()
@@ -89,8 +89,8 @@ func TestWithCodecNilIgnored(t *testing.T) {
 	client := jsonrpc2.NewConn(jsonrpc2.NewNDJSONStream(ca), jsonrpc2.WithCodec(nil))
 	server := jsonrpc2.NewConn(jsonrpc2.NewNDJSONStream(cb))
 	client.Go(ctx, jsonrpc2.MethodNotFoundHandler)
-	server.Go(ctx, func(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
-		return reply(ctx, req.Params(), nil)
+	server.Go(ctx, func(ctx context.Context, req *jsonrpc2.Request) (any, error) {
+		return jsonrpc2.RawMessage(string(req.Params())), nil
 	})
 	defer func() {
 		_ = client.Close()
@@ -117,8 +117,8 @@ func TestNewRawStreamRoundTrip(t *testing.T) {
 	client := jsonrpc2.NewConn(jsonrpc2.NewRawStream(ca))
 	server := jsonrpc2.NewConn(jsonrpc2.NewRawStream(cb))
 	client.Go(ctx, jsonrpc2.MethodNotFoundHandler)
-	server.Go(ctx, func(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
-		return reply(ctx, req.Params(), nil)
+	server.Go(ctx, func(ctx context.Context, req *jsonrpc2.Request) (any, error) {
+		return jsonrpc2.RawMessage(string(req.Params())), nil
 	})
 	defer func() {
 		_ = client.Close()
@@ -149,14 +149,14 @@ func TestRequestContextDeadline(t *testing.T) {
 
 	gotDeadline := make(chan time.Time, 1)
 	client.Go(parent, jsonrpc2.MethodNotFoundHandler)
-	server.Go(parent, func(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+	server.Go(parent, func(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 		dl, ok := ctx.Deadline()
 		if ok {
 			gotDeadline <- dl
 		} else {
 			gotDeadline <- time.Time{}
 		}
-		return reply(ctx, nil, nil)
+		return nil, nil
 	})
 	defer func() {
 		_ = client.Close()

--- a/api_test.go
+++ b/api_test.go
@@ -223,8 +223,8 @@ func TestListenAndServe(t *testing.T) {
 				runErr = jsonrpc2.ListenAndServe(ctx, network, addr, server, 0)
 			})
 
-			// ListenAndServe needs a moment to bind; retry the dial until it is up.
-			client, nc := dialWithRetry(t, network, addr)
+			// ListenAndServe needs a moment to bind; dialConn retries until it is up.
+			client, nc := dialConn(t, network, addr)
 			client.Go(ctx, jsonrpc2.MethodNotFoundHandler)
 
 			var got jsonrpc2.RawMessage
@@ -244,23 +244,5 @@ func TestListenAndServe(t *testing.T) {
 				t.Errorf("ListenAndServe returned %v, want context.Canceled", runErr)
 			}
 		})
-	}
-}
-
-// dialWithRetry dials addr, retrying briefly so a test does not race the server's
-// bind. It returns a client connection over the LSP header framing the server
-// uses, together with the underlying net.Conn for teardown.
-func dialWithRetry(t *testing.T, network, addr string) (jsonrpc2.Conn, net.Conn) {
-	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
-	for {
-		nc, err := net.DialTimeout(network, addr, time.Second)
-		if err == nil {
-			return jsonrpc2.NewConn(jsonrpc2.NewStream(nc)), nc
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("dial %s %s: %v", network, addr, err)
-		}
-		time.Sleep(20 * time.Millisecond)
 	}
 }

--- a/batch.go
+++ b/batch.go
@@ -32,45 +32,57 @@ type frameStream interface {
 const maxConnDirectUnmarshalResult = 64 << 10
 
 // readNext reads the next frame and classifies it. On success exactly one of
-// req, msgs, or resp is non-nil: resp is set for a single response, req for a
-// single request (the common, non-batch path, which carries no slice
-// allocation), and msgs for a batch of one or more requests with batch=true. A
-// batch frame containing only malformed entries still yields the slice so the
-// dispatcher can answer with error responses.
+// req, msgs, resp, or hasRV is set: resp for a single response, req for a
+// single request on the v1 interface path, hasRV (filling *rv) for a single
+// request scanned into the caller's concrete value on the direct-return path,
+// and msgs for a batch of one or more requests with batch=true. A batch frame
+// containing only malformed entries still yields the slice so the dispatcher
+// can answer with error responses.
 //
 // When the stream does not support raw frames, readNext falls back to the
 // single-message [Stream.Read] and never reports a batch.
-func (c *conn) readNext(ctx context.Context) (req Request, msgs []Request, resp *Response, batch bool, err error) {
+func (c *conn) readNext(ctx context.Context, rv *RequestV2) (req Request, msgs []Request, resp *Response, batch, hasRV bool, err error) {
 	fs, ok := c.stream.(frameStream)
 	if !ok {
 		var msg Message
 		msg, _, err = c.stream.Read(ctx)
 		if err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, nil, false, false, err
 		}
 		if r, isResp := msg.(*Response); isResp {
-			return nil, nil, r, false, nil
+			return nil, nil, r, false, false, nil
 		}
-		return msg.(Request), nil, nil, false, nil
+		return msg.(Request), nil, nil, false, false, nil
 	}
 
 	frame, _, ferr := fs.ReadFrame(ctx)
 	if ferr != nil {
-		return nil, nil, nil, false, ferr
+		return nil, nil, nil, false, false, ferr
 	}
 
 	i := skipSpace(frame, 0)
 	if i < len(frame) && frame[i] == '[' {
 		reqs, isBatch, perr := parseBatch(frame)
 		if perr != nil {
-			return nil, nil, nil, true, perr
+			return nil, nil, nil, true, false, perr
 		}
 		// An empty array is answered with a single (unbracketed) error response, so
 		// it is routed through the non-batch path with a single synthetic member.
 		if !isBatch && len(reqs) == 1 {
-			return reqs[0], nil, nil, false, nil
+			return reqs[0], nil, nil, false, false, nil
 		}
-		return nil, reqs, nil, isBatch, nil
+		return nil, reqs, nil, isBatch, false, nil
+	}
+
+	// Direct-return mode scans a single request straight into the caller's
+	// concrete value, skipping the message box. Frames it does not recognize
+	// (responses, malformed objects) fall through to the general paths below
+	// so their semantics are unchanged.
+	if c.directHandler != nil {
+		if scanned, sok := scanRequestV2(frame); sok {
+			*rv = scanned
+			return nil, nil, nil, false, true, nil
+		}
 	}
 
 	// The scanner recognizes only the canonical response envelope emitted by
@@ -80,18 +92,18 @@ func (c *conn) readNext(ctx context.Context) (req Request, msgs []Request, resp 
 	if id, result, ok, _ := scanPipelineResultResponseNumber(frame); ok {
 		if len(result) <= maxConnDirectUnmarshalResult {
 			c.deliverNumberResponse(id, result, nil)
-			return nil, nil, nil, false, nil
+			return nil, nil, nil, false, false, nil
 		}
 	}
 
 	msg, derr := DecodeMessage(frame)
 	if derr != nil {
-		return nil, nil, nil, false, derr
+		return nil, nil, nil, false, false, derr
 	}
 	if r, isResp := msg.(*Response); isResp {
-		return nil, nil, r, false, nil
+		return nil, nil, r, false, false, nil
 	}
-	return msg.(Request), nil, nil, false, nil
+	return msg.(Request), nil, nil, false, false, nil
 }
 
 // dispatch handles one frame's worth of requests. A single request is handled
@@ -106,6 +118,12 @@ func (c *conn) readNext(ctx context.Context) (req Request, msgs []Request, resp 
 // keeps its goroutine-per-member dispatch and never hands off the reader, so it
 // always reports false.
 func (c *conn) dispatch(ctx context.Context, handler Handler, req Request, msgs []Request, batch bool) (handedOff bool) {
+	if handler == nil {
+		// Direct-return mode reaches dispatch only for boxed leftovers: batch
+		// members and the synthetic empty-batch error member, both of which
+		// reply through the closure machinery via the adapter built in goDirect.
+		handler = c.compatHandler
+	}
 	if !batch {
 		if req != nil {
 			return c.handleRequest(ctx, handler, req)

--- a/batch.go
+++ b/batch.go
@@ -74,26 +74,28 @@ func (c *conn) readNext(ctx context.Context, rv *Request) (req RequestMessage, m
 		return nil, reqs, nil, isBatch, false, nil
 	}
 
-	// A single request scans straight into the caller's concrete value,
-	// skipping the message box. Frames the scanner does not recognize
-	// (responses, malformed objects) fall through to the general paths below
-	// so their semantics are unchanged. Client-only connections have no
-	// handler and skip the request scan entirely.
-	if c.handler != nil {
-		if scanned, sok := scanRequest(frame); sok {
-			*rv = scanned
-			return nil, nil, nil, false, true, nil
-		}
-	}
-
-	// The scanner recognizes only the canonical response envelope emitted by
-	// this package. It is an optimization gate, not the correctness boundary:
-	// non-canonical but valid responses must fall through to DecodeMessage so
-	// extension members remain decoder-compatible.
-	if id, result, ok, _ := scanPipelineResultResponseNumber(frame); ok {
-		if len(result) <= maxConnDirectUnmarshalResult {
-			c.deliverNumberResponse(id, result, nil)
-			return nil, nil, nil, false, false, nil
+	// A single classification scan records the frame's top-level member spans
+	// once. Requests fill the caller's concrete value directly (no message
+	// box); numeric-id success responses deliver their borrowed result inline,
+	// before the next read can invalidate it. Everything the classifier does
+	// not recognize -- malformed objects, error responses, string ids,
+	// oversized results -- falls through to the general decode path below, so
+	// those semantics are unchanged. This is an optimization gate, not the
+	// correctness boundary.
+	var f fields
+	if end, ok := scanObject(frame, &f); ok && skipSpace(frame, end) == len(frame) && f.validVersion() {
+		switch {
+		case f.hasMethod && !f.hasResult && !f.hasError:
+			// Client-only connections have no handler; their peers do not send
+			// requests, and a stray one takes the boxed fallback.
+			if c.handler != nil && f.fillRequest(rv) == nil {
+				return nil, nil, nil, false, true, nil
+			}
+		case !f.hasMethod && f.hasResult && !f.hasError && f.hasID && !isNullLiteral(f.id):
+			if id, idok := decodeID(f.id); idok && id.IsNumber() && len(f.result) <= maxConnDirectUnmarshalResult {
+				c.deliverNumberResponse(id.num, f.result, nil)
+				return nil, nil, nil, false, false, nil
+			}
 		}
 	}
 

--- a/batch.go
+++ b/batch.go
@@ -41,7 +41,7 @@ const maxConnDirectUnmarshalResult = 64 << 10
 //
 // When the stream does not support raw frames, readNext falls back to the
 // single-message [Stream.Read] and never reports a batch.
-func (c *conn) readNext(ctx context.Context, rv *RequestV2) (req Request, msgs []Request, resp *Response, batch, hasRV bool, err error) {
+func (c *conn) readNext(ctx context.Context, rv *Request) (req RequestMessage, msgs []RequestMessage, resp *Response, batch, hasRV bool, err error) {
 	fs, ok := c.stream.(frameStream)
 	if !ok {
 		var msg Message
@@ -52,7 +52,7 @@ func (c *conn) readNext(ctx context.Context, rv *RequestV2) (req Request, msgs [
 		if r, isResp := msg.(*Response); isResp {
 			return nil, nil, r, false, false, nil
 		}
-		return msg.(Request), nil, nil, false, false, nil
+		return msg.(RequestMessage), nil, nil, false, false, nil
 	}
 
 	frame, _, ferr := fs.ReadFrame(ctx)
@@ -74,12 +74,13 @@ func (c *conn) readNext(ctx context.Context, rv *RequestV2) (req Request, msgs [
 		return nil, reqs, nil, isBatch, false, nil
 	}
 
-	// Direct-return mode scans a single request straight into the caller's
-	// concrete value, skipping the message box. Frames it does not recognize
+	// A single request scans straight into the caller's concrete value,
+	// skipping the message box. Frames the scanner does not recognize
 	// (responses, malformed objects) fall through to the general paths below
-	// so their semantics are unchanged.
-	if c.directHandler != nil {
-		if scanned, sok := scanRequestV2(frame); sok {
+	// so their semantics are unchanged. Client-only connections have no
+	// handler and skip the request scan entirely.
+	if c.handler != nil {
+		if scanned, sok := scanRequest(frame); sok {
 			*rv = scanned
 			return nil, nil, nil, false, true, nil
 		}
@@ -103,34 +104,28 @@ func (c *conn) readNext(ctx context.Context, rv *RequestV2) (req Request, msgs [
 	if r, isResp := msg.(*Response); isResp {
 		return nil, nil, r, false, false, nil
 	}
-	return msg.(Request), nil, nil, false, false, nil
+	return msg.(RequestMessage), nil, nil, false, false, nil
 }
 
-// dispatch handles one frame's worth of requests. A single request is handled
-// inline so the common single-message path carries neither slice nor batch
-// overhead; a batch is handled member by member, collecting the responses for
-// the call members into a single array that is written with one frame, while a
-// batch made up entirely of notifications produces no response per the
-// JSON-RPC 2.0 specification.
+// dispatch handles one frame's worth of boxed requests: the rare
+// single-message fallbacks (a non-frame stream's Read, or the synthetic
+// empty-batch error member) and batch arrays. A batch is handled member by
+// member, collecting the responses for the call members into a single array
+// that is written with one frame, while a batch made up entirely of
+// notifications produces no response per the JSON-RPC 2.0 specification.
 //
 // It reports handedOff=true when an inline single-message handler released the
 // read loop with [Async] and a successor reader has taken over. The batch path
 // keeps its goroutine-per-member dispatch and never hands off the reader, so it
 // always reports false.
-func (c *conn) dispatch(ctx context.Context, handler Handler, req Request, msgs []Request, batch bool) (handedOff bool) {
-	if handler == nil {
-		// Direct-return mode reaches dispatch only for boxed leftovers: batch
-		// members and the synthetic empty-batch error member, both of which
-		// reply through the closure machinery via the adapter built in goDirect.
-		handler = c.compatHandler
-	}
+func (c *conn) dispatch(ctx context.Context, req RequestMessage, msgs []RequestMessage, batch bool) (handedOff bool) {
 	if !batch {
 		if req != nil {
-			return c.handleRequest(ctx, handler, req)
+			return c.handleBoxedRequest(ctx, req)
 		}
 		return false
 	}
-	c.dispatchBatch(ctx, handler, msgs)
+	c.dispatchBatch(ctx, msgs)
 	return false
 }
 
@@ -146,7 +141,7 @@ type batchCollector struct {
 
 // dispatchBatch parses, validates, and handles each member of a batch, then
 // writes the collected responses as a single array frame.
-func (c *conn) dispatchBatch(ctx context.Context, handler Handler, msgs []Request) {
+func (c *conn) dispatchBatch(ctx context.Context, msgs []RequestMessage) {
 	// An empty array, or a non-array element where an object was required, has
 	// already been turned into a single InvalidRequest member by parseBatch, so
 	// msgs is never empty here.
@@ -163,7 +158,7 @@ func (c *conn) dispatchBatch(ctx context.Context, handler Handler, msgs []Reques
 	}
 
 	for _, req := range msgs {
-		c.handleBatchMember(ctx, handler, req, bc)
+		c.handleBatchMember(ctx, req, bc)
 	}
 
 	bc.finish(ctx)
@@ -226,7 +221,7 @@ func (bc *batchCollector) write(ctx context.Context, resps []responseWire) {
 // invalid member; any non-empty array returns isBatch=true. A member that is not
 // a valid request object yields an InvalidRequest member in its place so the
 // valid members are still handled.
-func parseBatch(frame []byte) (reqs []Request, isBatch bool, err error) {
+func parseBatch(frame []byte) (reqs []RequestMessage, isBatch bool, err error) {
 	parsed, perr := ParseRequests(frame)
 	if perr != nil {
 		return nil, false, perr
@@ -234,10 +229,10 @@ func parseBatch(frame []byte) (reqs []Request, isBatch bool, err error) {
 	if len(parsed) == 0 {
 		// An empty batch "[]" is answered with a single error response carrying a
 		// null id, not a one-element array.
-		return []Request{invalidBatchMember(ErrInvalidRequest)}, false, nil
+		return []RequestMessage{invalidBatchMember(ErrInvalidRequest)}, false, nil
 	}
 
-	out := make([]Request, 0, len(parsed))
+	out := make([]RequestMessage, 0, len(parsed))
 	for _, pm := range parsed {
 		if pm.Err != nil {
 			out = append(out, invalidBatchMember(pm.Err))
@@ -251,11 +246,11 @@ func parseBatch(frame []byte) (reqs []Request, isBatch bool, err error) {
 // invalidBatchMember builds a placeholder call that carries no real id and is
 // answered with err. It lets a malformed batch member flow through the normal
 // dispatch path and produce a spec-compliant error response with a null id.
-func invalidBatchMember(err *Error) Request {
+func invalidBatchMember(err *Error) RequestMessage {
 	return &invalidRequest{err: err}
 }
 
-// invalidRequest is a synthetic [Request] standing in for a malformed batch
+// invalidRequest is a synthetic [RequestMessage] standing in for a malformed batch
 // member. It is always answered with a null-id error response and never reaches
 // the user handler.
 type invalidRequest struct {
@@ -272,7 +267,7 @@ func (*invalidRequest) jsonrpc2Request() {}
 
 // respondsInBatch reports whether req contributes a response body to a batch's
 // response array: calls and malformed members do, notifications do not.
-func respondsInBatch(req Request) bool {
+func respondsInBatch(req RequestMessage) bool {
 	switch req.(type) {
 	case *Call, *invalidRequest:
 		return true

--- a/batch.go
+++ b/batch.go
@@ -31,6 +31,14 @@ type frameStream interface {
 // goroutine and cannot head-of-line block unrelated incoming frames.
 const maxConnDirectUnmarshalResult = 64 << 10
 
+type nextRead struct {
+	req   RequestMessage
+	msgs  []RequestMessage
+	resp  *Response
+	batch bool
+	hasRV bool
+}
+
 // readNext reads the next frame and classifies it. On success exactly one of
 // req, msgs, resp, or hasRV is set: resp for a single response, req for a
 // single request on the v1 interface path, hasRV (filling *rv) for a single
@@ -41,39 +49,60 @@ const maxConnDirectUnmarshalResult = 64 << 10
 //
 // When the stream does not support raw frames, readNext falls back to the
 // single-message [Stream.Read] and never reports a batch.
-func (c *conn) readNext(ctx context.Context, rv *Request) (req RequestMessage, msgs []RequestMessage, resp *Response, batch, hasRV bool, err error) {
+func (c *conn) readNext(ctx context.Context, rv *Request) (nextRead, error) {
 	fs, ok := c.stream.(frameStream)
 	if !ok {
-		var msg Message
-		msg, _, err = c.stream.Read(ctx)
-		if err != nil {
-			return nil, nil, nil, false, false, err
-		}
-		if r, isResp := msg.(*Response); isResp {
-			return nil, nil, r, false, false, nil
-		}
-		return msg.(RequestMessage), nil, nil, false, false, nil
+		return c.readNextMessage(ctx)
 	}
 
 	frame, _, ferr := fs.ReadFrame(ctx)
 	if ferr != nil {
-		return nil, nil, nil, false, false, ferr
+		return nextRead{}, ferr
 	}
+	return c.classifyFrame(frame, rv)
+}
 
+func (c *conn) readNextMessage(ctx context.Context) (nextRead, error) {
+	msg, _, err := c.stream.Read(ctx)
+	if err != nil {
+		return nextRead{}, err
+	}
+	if r, isResp := msg.(*Response); isResp {
+		return nextRead{resp: r}, nil
+	}
+	return nextRead{req: msg.(RequestMessage)}, nil
+}
+
+func (c *conn) classifyFrame(frame []byte, rv *Request) (nextRead, error) {
 	i := skipSpace(frame, 0)
 	if i < len(frame) && frame[i] == '[' {
-		reqs, isBatch, perr := parseBatch(frame)
-		if perr != nil {
-			return nil, nil, nil, true, false, perr
-		}
-		// An empty array is answered with a single (unbracketed) error response, so
-		// it is routed through the non-batch path with a single synthetic member.
-		if !isBatch && len(reqs) == 1 {
-			return reqs[0], nil, nil, false, false, nil
-		}
-		return nil, reqs, nil, isBatch, false, nil
+		return c.classifyBatchFrame(frame)
 	}
 
+	hasScannedRequest, deliveredResponse := c.classifyScannedFrame(frame, rv)
+	if hasScannedRequest {
+		return nextRead{hasRV: true}, nil
+	}
+	if deliveredResponse {
+		return nextRead{}, nil
+	}
+	return decodeFrameMessage(frame)
+}
+
+func (c *conn) classifyBatchFrame(frame []byte) (nextRead, error) {
+	reqs, isBatch, err := parseBatch(frame)
+	if err != nil {
+		return nextRead{batch: true}, err
+	}
+	// An empty array is answered with a single (unbracketed) error response, so
+	// it is routed through the non-batch path with a single synthetic member.
+	if !isBatch && len(reqs) == 1 {
+		return nextRead{req: reqs[0]}, nil
+	}
+	return nextRead{msgs: reqs, batch: isBatch}, nil
+}
+
+func (c *conn) classifyScannedFrame(frame []byte, rv *Request) (hasRequest, deliveredResponse bool) {
 	// A single classification scan records the frame's top-level member spans
 	// once. Requests fill the caller's concrete value directly (no message
 	// box); numeric-id success responses deliver their borrowed result inline,
@@ -83,30 +112,43 @@ func (c *conn) readNext(ctx context.Context, rv *Request) (req RequestMessage, m
 	// those semantics are unchanged. This is an optimization gate, not the
 	// correctness boundary.
 	var f fields
-	if end, ok := scanObject(frame, &f); ok && skipSpace(frame, end) == len(frame) && f.validVersion() {
-		switch {
-		case f.hasMethod && !f.hasResult && !f.hasError:
-			// Client-only connections have no handler; their peers do not send
-			// requests, and a stray one takes the boxed fallback.
-			if c.handler != nil && f.fillRequest(rv) == nil {
-				return nil, nil, nil, false, true, nil
-			}
-		case !f.hasMethod && f.hasResult && !f.hasError && f.hasID && !isNullLiteral(f.id):
-			if id, idok := decodeID(f.id); idok && id.IsNumber() && len(f.result) <= maxConnDirectUnmarshalResult {
-				c.deliverNumberResponse(id.num, f.result, nil)
-				return nil, nil, nil, false, false, nil
-			}
-		}
+	if !scanValidObject(frame, &f) {
+		return false, false
 	}
+	// Client-only connections have no handler; their peers do not send
+	// requests, and a stray one takes the boxed fallback.
+	if c.handler != nil && f.hasMethod && !f.hasResult && !f.hasError {
+		return f.fillRequest(rv) == nil, false
+	}
+	return false, c.deliverScannedNumberFields(&f)
+}
 
-	msg, derr := DecodeMessage(frame)
-	if derr != nil {
-		return nil, nil, nil, false, false, derr
+func (c *conn) deliverScannedNumberFields(f *fields) bool {
+	if f.hasMethod || !f.hasResult || f.hasError || !f.hasID || isNullLiteral(f.id) {
+		return false
+	}
+	id, ok := decodeID(f.id)
+	if !ok || !id.IsNumber() || len(f.result) > maxConnDirectUnmarshalResult {
+		return false
+	}
+	c.deliverNumberResponse(id.num, f.result, nil)
+	return true
+}
+
+func decodeFrameMessage(frame []byte) (nextRead, error) {
+	msg, err := DecodeMessage(frame)
+	if err != nil {
+		return nextRead{}, err
 	}
 	if r, isResp := msg.(*Response); isResp {
-		return nil, nil, r, false, false, nil
+		return nextRead{resp: r}, nil
 	}
-	return msg.(RequestMessage), nil, nil, false, false, nil
+	return nextRead{req: msg.(RequestMessage)}, nil
+}
+
+func scanValidObject(frame []byte, f *fields) bool {
+	end, ok := scanObject(frame, f)
+	return ok && skipSpace(frame, end) == len(frame) && f.validVersion()
 }
 
 // dispatch handles one frame's worth of boxed requests: the rare

--- a/batch_test.go
+++ b/batch_test.go
@@ -65,14 +65,14 @@ func (p *batchPeer) readFrame(t *testing.T, timeout time.Duration) (string, bool
 	}
 }
 
-func batchHandler(ctx context.Context, reply Replier, req Request) error {
+func batchHandler(ctx context.Context, req *Request) (any, error) {
 	switch req.Method() {
 	case "sum":
-		return reply(ctx, raw(string(orNull(req.Params()))), nil)
+		return raw(string(orNull(req.Params()))), nil
 	case "note":
-		return reply(ctx, nil, nil)
+		return nil, nil
 	default:
-		return MethodNotFoundHandler(ctx, reply, req)
+		return MethodNotFoundHandler(ctx, req)
 	}
 }
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -71,7 +71,7 @@ func BenchmarkVoidRoundTrip(b *testing.B) {
 	client := NewConn(NewNDJSONStream(ca))
 	server := NewConn(NewNDJSONStream(cb))
 	client.Go(ctx, MethodNotFoundHandler)
-	server.GoDirect(ctx, func(ctx context.Context, req *RequestV2) (any, error) {
+	server.Go(ctx, func(ctx context.Context, req *Request) (any, error) {
 		return nil, nil
 	})
 	defer func() {
@@ -347,8 +347,8 @@ func BenchmarkSyncClientVoidRoundTrip(b *testing.B) {
 		b.Fatalf("NewSyncClient: %v", err)
 	}
 	server := NewConn(NewNDJSONStream(cb))
-	server.Go(ctx, func(ctx context.Context, reply Replier, req Request) error {
-		return reply(ctx, nil, nil)
+	server.Go(ctx, func(ctx context.Context, req *Request) (any, error) {
+		return nil, nil
 	})
 	defer func() {
 		_ = client.Close()
@@ -394,8 +394,8 @@ func benchmarkPipelinedVoidRoundTrip(b *testing.B, inflight int, newClient func(
 	client := newClient(NewNDJSONStream(ca))
 	server := NewServer(NewNDJSONStream(cb))
 	client.Go(ctx, MethodNotFoundHandler)
-	server.Go(ctx, func(ctx context.Context, reply Replier, req Request) error {
-		return reply(ctx, nil, nil)
+	server.Go(ctx, func(ctx context.Context, req *Request) (any, error) {
+		return nil, nil
 	})
 	defer func() {
 		_ = client.Close()

--- a/bench_test.go
+++ b/bench_test.go
@@ -71,7 +71,7 @@ func BenchmarkVoidRoundTrip(b *testing.B) {
 	client := NewConn(NewNDJSONStream(ca))
 	server := NewConn(NewNDJSONStream(cb))
 	client.Go(ctx, MethodNotFoundHandler)
-	server.(*conn).goDirect(ctx, func(ctx context.Context, req *RequestV2) (any, error) {
+	server.GoDirect(ctx, func(ctx context.Context, req *RequestV2) (any, error) {
 		return nil, nil
 	})
 	defer func() {

--- a/bench_test.go
+++ b/bench_test.go
@@ -71,8 +71,8 @@ func BenchmarkVoidRoundTrip(b *testing.B) {
 	client := NewConn(NewNDJSONStream(ca))
 	server := NewConn(NewNDJSONStream(cb))
 	client.Go(ctx, MethodNotFoundHandler)
-	server.Go(ctx, func(ctx context.Context, reply Replier, req Request) error {
-		return reply(ctx, nil, nil)
+	server.(*conn).goDirect(ctx, func(ctx context.Context, req *RequestV2) (any, error) {
+		return nil, nil
 	})
 	defer func() {
 		_ = client.Close()

--- a/bench_test.go
+++ b/bench_test.go
@@ -62,7 +62,7 @@ func makeBenchmarkLargeCall(n int) []byte {
 	return out
 }
 
-// BenchmarkVoidRoundTrip measures the AC-P1 hot path: a call with nil params to
+// BenchmarkVoidRoundTrip measures the headline hot path: a call with nil params to
 // a handler that replies with a nil result, in the default synchronous dispatch
 // mode, over an in-memory net.Pipe. It reports ns/op and allocs/op.
 func BenchmarkVoidRoundTrip(b *testing.B) {

--- a/bidir_test.go
+++ b/bidir_test.go
@@ -41,29 +41,29 @@ func TestBidirectionalServerInitiatedCall(t *testing.T) {
 	// A serves "answer" with a known value: this is the server-initiated call B
 	// makes back into the connection while serving "ask".
 	a := NewConn(ea.stream)
-	a.Go(ctx, func(ctx context.Context, reply Replier, req Request) error {
+	a.Go(ctx, func(ctx context.Context, req *Request) (any, error) {
 		if req.Method() == "answer" {
-			return reply(ctx, raw(`"forty-two"`), nil)
+			return raw(`"forty-two"`), nil
 		}
-		return MethodNotFoundHandler(ctx, reply, req)
+		return MethodNotFoundHandler(ctx, req)
 	})
 
 	// B serves "ask" by releasing the read loop with Async, calling back to A's
 	// "answer", and replying with a value derived from A's result. The handler
 	// closure observes b only after Go starts the read loop.
 	b := NewConn(eb.stream)
-	b.Go(ctx, func(ctx context.Context, reply Replier, req Request) error {
+	b.Go(ctx, func(ctx context.Context, req *Request) (any, error) {
 		if req.Method() != "ask" {
-			return MethodNotFoundHandler(ctx, reply, req)
+			return MethodNotFoundHandler(ctx, req)
 		}
 		// Release the read loop so the response to the callback below can be read;
 		// without this the reentrant call deadlocks.
 		Async(ctx)
 		var inner RawMessage
 		if _, err := b.Call(ctx, "answer", nil, &inner); err != nil {
-			return reply(ctx, nil, err)
+			return nil, err
 		}
-		return reply(ctx, raw(`{"relayed":`+string(inner)+`}`), nil)
+		return raw(`{"relayed":` + string(inner) + `}`), nil
 	})
 	defer closeBoth(t, a, b)
 
@@ -107,24 +107,24 @@ func TestServerInitiatedNotificationFromHandlerWithoutAsync(t *testing.T) {
 	// one) so A's handler never blocks on the send.
 	observed := make(chan string, 1)
 	a := NewConn(ea.stream)
-	a.Go(ctx, func(ctx context.Context, reply Replier, req Request) error {
+	a.Go(ctx, func(ctx context.Context, req *Request) (any, error) {
 		if req.Method() == "event" {
 			observed <- string(orNull(req.Params()))
-			return reply(ctx, nil, nil) // no-op for a notification
+			return nil, nil // a notification has no response.
 		}
-		return MethodNotFoundHandler(ctx, reply, req)
+		return MethodNotFoundHandler(ctx, req)
 	})
 
 	// B serves "ask" by notifying A back (no Async needed) and then replying.
 	b := NewConn(eb.stream)
-	b.Go(ctx, func(ctx context.Context, reply Replier, req Request) error {
+	b.Go(ctx, func(ctx context.Context, req *Request) (any, error) {
 		if req.Method() != "ask" {
-			return MethodNotFoundHandler(ctx, reply, req)
+			return MethodNotFoundHandler(ctx, req)
 		}
 		if err := b.Notify(ctx, "event", raw(`{"n":1}`)); err != nil {
-			return reply(ctx, nil, err)
+			return nil, err
 		}
-		return reply(ctx, raw(`"ok"`), nil)
+		return raw(`"ok"`), nil
 	})
 	defer closeBoth(t, a, b)
 
@@ -174,24 +174,24 @@ func TestGoroutineLeakBidirectional(t *testing.T) {
 		ea, eb := memTransport(NewNDJSONStream)(t)
 
 		a := NewConn(ea.stream)
-		a.Go(ctx, func(ctx context.Context, reply Replier, req Request) error {
+		a.Go(ctx, func(ctx context.Context, req *Request) (any, error) {
 			if req.Method() == "answer" {
-				return reply(ctx, raw(`"v"`), nil)
+				return raw(`"v"`), nil
 			}
-			return MethodNotFoundHandler(ctx, reply, req)
+			return MethodNotFoundHandler(ctx, req)
 		})
 
 		b := NewConn(eb.stream)
-		b.Go(ctx, func(ctx context.Context, reply Replier, req Request) error {
+		b.Go(ctx, func(ctx context.Context, req *Request) (any, error) {
 			if req.Method() != "ask" {
-				return MethodNotFoundHandler(ctx, reply, req)
+				return MethodNotFoundHandler(ctx, req)
 			}
 			Async(ctx)
 			var inner RawMessage
 			if _, err := b.Call(ctx, "answer", nil, &inner); err != nil {
-				return reply(ctx, nil, err)
+				return nil, err
 			}
-			return reply(ctx, raw(string(inner)), nil)
+			return raw(string(inner)), nil
 		})
 
 		for range 3 {

--- a/channel_stream.go
+++ b/channel_stream.go
@@ -9,6 +9,40 @@ import (
 	"sync"
 )
 
+// frameBuf is a pooled channel-stream frame. The pointer-to-struct shape keeps
+// sync.Pool round trips allocation-free: the same *frameBuf box travels from
+// the composing writer through the data channel to the reader and back to the
+// pool, so steady-state traffic recycles both the box and its byte array.
+type frameBuf struct {
+	b []byte
+}
+
+// frameBufPool recycles channel-stream frames across all stream pairs.
+// Ownership is exclusive at every instant: a frameBuf is held by exactly one
+// of the pool, a composing writer, a data channel, or the delivered reader.
+var frameBufPool = sync.Pool{
+	New: func() any {
+		return &frameBuf{b: make([]byte, 0, encodeBufInitCap)}
+	},
+}
+
+// getFrameBuf returns a frame with a reset, possibly recycled byte array.
+func getFrameBuf() *frameBuf {
+	fb := frameBufPool.Get().(*frameBuf)
+	fb.b = fb.b[:0]
+	return fb
+}
+
+// putFrameBuf returns fb to the pool unless its array has grown beyond
+// encodeBufMaxCap, in which case the frame is dropped so the oversized array
+// can be collected (mirroring putEncodeBuf's policy).
+func putFrameBuf(fb *frameBuf) {
+	if cap(fb.b) > encodeBufMaxCap {
+		return
+	}
+	frameBufPool.Put(fb)
+}
+
 // NewChannelStreamPair returns two connected in-memory streams backed by
 // bounded channels of encoded JSON-RPC frames.
 //
@@ -20,36 +54,48 @@ import (
 // transport; it is not a replacement for network or stdio transports.
 //
 // Frames sent with WriteFrame are copied before they are queued, so the caller
-// may reuse or mutate its buffer immediately after WriteFrame returns. Frames
-// returned by ReadFrame are owned by the receiving stream. Closing either stream
-// closes the pair, makes later reads and writes fail with io.EOF, and unblocks
-// pending reads and writes with io.EOF.
+// may reuse or mutate its buffer immediately after WriteFrame returns. A frame
+// returned by ReadFrame is valid only until the next read on the same stream:
+// delivered frames are recycled through a frame pool, which is what lets
+// steady-state traffic queue frames without copying or allocating. Each stream
+// supports one reader at a time, matching the package's connection read loop.
+// Closing either stream closes the pair, makes later reads and writes fail
+// with io.EOF, and unblocks pending reads and writes with io.EOF.
 func NewChannelStreamPair(capacity int) (left, right Stream) {
 	if capacity < 0 {
 		panic("jsonrpc2: negative channel stream capacity")
 	}
 	p := &channelStreamPair{
 		done: make(chan struct{}),
-		aToB: make(chan []byte, capacity),
-		bToA: make(chan []byte, capacity),
+		aToB: make(chan *frameBuf, capacity),
+		bToA: make(chan *frameBuf, capacity),
 	}
 	return &channelStream{in: p.bToA, out: p.aToB, pair: p}, &channelStream{in: p.aToB, out: p.bToA, pair: p}
 }
 
 type channelStreamPair struct {
 	done chan struct{}
-	aToB chan []byte
-	bToA chan []byte
+	aToB chan *frameBuf
+	bToA chan *frameBuf
 	once sync.Once
 }
 
 type channelStream struct {
-	in   <-chan []byte
-	out  chan<- []byte
+	in   <-chan *frameBuf
+	out  chan<- *frameBuf
 	pair *channelStreamPair
 
-	wbuf []byte
+	// lastBuf is the frame most recently delivered by ReadFrame. The next
+	// ReadFrame recycles it, which is what bounds a delivered frame's validity
+	// to "until the next read". It is only touched by the stream's single
+	// reader goroutine.
+	lastBuf *frameBuf
 
+	// writeMu serializes concurrent senders in front of the data channel.
+	// Funneling senders through a mutex keeps them off the multi-channel
+	// select: without it, every blocked sender parks on (and is woken by) all
+	// three select cases, and the select-lock contention measurably regresses
+	// the parallel round-trip rows.
 	writeMu sync.Mutex
 }
 
@@ -70,10 +116,18 @@ func (s *channelStream) Write(ctx context.Context, msg Message) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return s.sendFrame(ctx, frame)
+	// Adopt the encoded frame's array rather than copying it; the recycled
+	// array the frame carried is dropped for the collector.
+	fb := getFrameBuf()
+	fb.b = frame
+	return s.sendFrame(ctx, fb)
 }
 
 func (s *channelStream) ReadFrame(ctx context.Context) (frame []byte, n int64, err error) {
+	if last := s.lastBuf; last != nil {
+		s.lastBuf = nil
+		putFrameBuf(last)
+	}
 	if err := s.closedOrCanceled(ctx); err != nil {
 		return nil, 0, err
 	}
@@ -82,13 +136,22 @@ func (s *channelStream) ReadFrame(ctx context.Context) (frame []byte, n int64, e
 		return nil, 0, ctx.Err()
 	case <-s.pair.done:
 		return nil, 0, io.EOF
-	case frame := <-s.in:
-		return frame, int64(len(frame)), nil
+	case fb := <-s.in:
+		s.lastBuf = fb
+		return fb.b, int64(len(fb.b)), nil
 	}
 }
 
 func (s *channelStream) WriteFrame(ctx context.Context, data []byte) (int64, error) {
-	return s.sendFrame(ctx, cloneBytes(data))
+	// The WriteFrame contract lets the caller reuse its buffer immediately, so
+	// the data is copied -- but into a recycled frame, not a fresh allocation.
+	fb := getFrameBuf()
+	fb.b = append(fb.b, data...)
+	n, err := s.sendFrame(ctx, fb)
+	if err != nil {
+		putFrameBuf(fb)
+	}
+	return n, err
 }
 
 func (s *channelStream) writeCall(ctx context.Context, id ID, method string, params RawMessage) (int64, error) {
@@ -109,29 +172,42 @@ func (s *channelStream) writeResponse(ctx context.Context, id ID, result RawMess
 	})
 }
 
+// composeAndSend appends one frame into a pooled buffer and hands the buffer's
+// ownership to the receiving end through the data channel. No copy is queued:
+// the receiver recycles the frame when it is retired by the next read.
 func (s *channelStream) composeAndSend(ctx context.Context, appendFrame func([]byte) []byte) (int64, error) {
 	if err := ctx.Err(); err != nil {
 		return 0, err
 	}
-	s.writeMu.Lock()
-	frame := appendFrame(s.wbuf[:0])
-	queued := cloneBytes(frame)
-	s.wbuf = frame
-	s.writeMu.Unlock()
-	return s.sendFrame(ctx, queued)
+	fb := getFrameBuf()
+	fb.b = appendFrame(fb.b)
+	n, err := s.sendFrame(ctx, fb)
+	if err != nil {
+		putFrameBuf(fb)
+	}
+	return n, err
 }
 
-func (s *channelStream) sendFrame(ctx context.Context, frame []byte) (int64, error) {
+func (s *channelStream) sendFrame(ctx context.Context, fb *frameBuf) (int64, error) {
 	if err := s.closedOrCanceled(ctx); err != nil {
 		return 0, err
 	}
+	// The frame's ownership transfers the instant the channel send succeeds; a
+	// fast receiver can retire and recycle it before this function returns, so
+	// the reported length must be read before the send.
+	n := int64(len(fb.b))
+	// Holding writeMu across a blocking send is safe: the receiving end never
+	// takes this mutex, and Close (or cancellation) still unblocks the send
+	// through the selected done channels, after which the mutex is released.
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
 	select {
 	case <-ctx.Done():
 		return 0, ctx.Err()
 	case <-s.pair.done:
 		return 0, io.EOF
-	case s.out <- frame:
-		return int64(len(frame)), nil
+	case s.out <- fb:
+		return n, nil
 	}
 }
 

--- a/channel_stream.go
+++ b/channel_stream.go
@@ -99,6 +99,8 @@ type channelStream struct {
 	writeMu sync.Mutex
 }
 
+// Read implements [Stream]. A decoded request's method and params borrow the
+// delivered frame, which is recycled at the next read; copy what you retain.
 func (s *channelStream) Read(ctx context.Context) (Message, int64, error) {
 	frame, n, err := s.ReadFrame(ctx)
 	if err != nil {
@@ -120,7 +122,11 @@ func (s *channelStream) Write(ctx context.Context, msg Message) (int64, error) {
 	// array the frame carried is dropped for the collector.
 	fb := getFrameBuf()
 	fb.b = frame
-	return s.sendFrame(ctx, fb)
+	n, serr := s.sendFrame(ctx, fb)
+	if serr != nil {
+		putFrameBuf(fb)
+	}
+	return n, serr
 }
 
 func (s *channelStream) ReadFrame(ctx context.Context) (frame []byte, n int64, err error) {

--- a/channel_stream_test.go
+++ b/channel_stream_test.go
@@ -17,8 +17,8 @@ func TestChannelStreamPairRoundTrip(t *testing.T) {
 	client := NewConn(clientStream)
 	server := NewConn(serverStream)
 	client.Go(ctx, MethodNotFoundHandler)
-	server.Go(ctx, func(ctx context.Context, reply Replier, req Request) error {
-		return reply(ctx, RawMessage(`{"ok":true}`), nil)
+	server.Go(ctx, func(ctx context.Context, req *Request) (any, error) {
+		return RawMessage(`{"ok":true}`), nil
 	})
 	defer func() {
 		_ = client.Close()

--- a/compat_test.go
+++ b/compat_test.go
@@ -46,15 +46,14 @@ type sumResult struct {
 type methodMap map[string]func(ctx context.Context, params jsonrpc2.RawMessage) (any, error)
 
 // handler adapts the method map to a single [jsonrpc2.Handler]. It decodes the
-// raw params with the default codec, invokes the typed handler, and replies with
-// the typed result (or the JSON-RPC error the handler returns).
-func (m methodMap) handler(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+// raw params with the default codec, invokes the typed handler, and returns the
+// typed result (or the JSON-RPC error the handler returns) as the response.
+func (m methodMap) handler(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	fn, ok := m[req.Method()]
 	if !ok {
-		return reply(ctx, nil, jsonrpc2.ErrMethodNotFound)
+		return nil, jsonrpc2.ErrMethodNotFound
 	}
-	result, err := fn(ctx, req.Params())
-	return reply(ctx, result, err)
+	return fn(ctx, req.Params())
 }
 
 // TestDownstreamCompatShim proves the gopls-style usage compiles and round-trips
@@ -151,19 +150,21 @@ func TestDownstreamNotify(t *testing.T) {
 	// "didChange" notification, giving the test a deterministic, sleep-free
 	// handshake instead of polling shared state.
 	notified := make(chan jsonrpc2.RawMessage, 1)
-	server := jsonrpc2.HandlerServer(func(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+	server := jsonrpc2.HandlerServer(func(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 		switch req.Method() {
 		case "didChange":
-			// A notification: reply is a no-op, but record that it arrived.
+			// A notification: there is nothing to return, but record that it
+			// arrived. The params bytes are borrowed and die when the handler
+			// returns, so copy them before handing them to the channel.
 			select {
-			case notified <- req.Params():
+			case notified <- jsonrpc2.RawMessage(string(req.Params())):
 			default:
 			}
-			return reply(ctx, nil, nil)
+			return nil, nil
 		case "ping":
-			return reply(ctx, jsonrpc2.RawMessage(`"pong"`), nil)
+			return jsonrpc2.RawMessage(`"pong"`), nil
 		default:
-			return reply(ctx, nil, jsonrpc2.ErrMethodNotFound)
+			return jsonrpc2.MethodNotFoundHandler(ctx, req)
 		}
 	})
 
@@ -219,20 +220,19 @@ func TestDownstreamCancel(t *testing.T) {
 
 	gotID := make(chan jsonrpc2.ID, 1)
 	handlerErr := make(chan error, 1)
-	base := func(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+	base := func(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 		if req.Method() != "longRunning" {
-			return reply(ctx, nil, jsonrpc2.ErrMethodNotFound)
+			return nil, jsonrpc2.ErrMethodNotFound
 		}
 		// Report the id the connection assigned so the test can cancel it.
-		gotID <- req.(*jsonrpc2.Call).ID()
+		gotID <- req.ID()
 		<-ctx.Done()
 		handlerErr <- ctx.Err()
-		// Reply on a context detached from the (now-canceled) request context so
-		// the cancellation outcome is actually delivered to the caller. Replying
-		// on the canceled ctx would short-circuit the write, leaving the caller to
-		// observe only the connection teardown; a downstream consumer that wants
-		// to report "your request was canceled" detaches like this.
-		return reply(context.WithoutCancel(ctx), nil, ctx.Err())
+		// Return the cancellation as the call's error response: the connection
+		// writes the response from the handler's return values outside the
+		// canceled per-call context, so the outcome is delivered to the caller
+		// without the detached-context reply the closure API needed.
+		return nil, ctx.Err()
 	}
 	h, canceller := jsonrpc2.CancelHandler(jsonrpc2.AsyncHandler(base))
 	server := jsonrpc2.HandlerServer(h)
@@ -272,10 +272,10 @@ func TestDownstreamCancel(t *testing.T) {
 		t.Fatal("handler was not canceled")
 	}
 
-	// The blocked call returns the error response the handler replied with. The
-	// handler replied with ctx.Err(), which crosses the wire as a JSON-RPC error
-	// object, so the client observes a *jsonrpc2.Error carrying the cancellation
-	// message rather than the sentinel context.Canceled itself.
+	// The blocked call returns the error response built from the handler's
+	// return values. The handler returned ctx.Err(), which crosses the wire as a
+	// JSON-RPC error object, so the client observes a *jsonrpc2.Error carrying
+	// the cancellation message rather than the sentinel context.Canceled itself.
 	select {
 	case err := <-callErr:
 		if err == nil {

--- a/compat_test.go
+++ b/compat_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"strconv"
 	"testing"
 	"time"
 
@@ -15,8 +16,8 @@ import (
 	"go.lsp.dev/jsonrpc2"
 )
 
-// This file is the AC-X2 downstream-compatibility shim. It exercises the public
-// surface the way a consumer such as go.lsp.dev/protocol would: a method map
+// This file exercises the public surface the way a downstream consumer such as
+// go.lsp.dev/protocol would: a method map
 // dispatched through a single [jsonrpc2.Handler], served by [jsonrpc2.Serve] +
 // [jsonrpc2.HandlerServer], and driven by a client [jsonrpc2.Conn.Call] with
 // typed params and results routed through the default codec.
@@ -68,7 +69,7 @@ func TestDownstreamCompatShim(t *testing.T) {
 			if err := jsonrpc2.DefaultCodec.Unmarshal(params, &p); err != nil {
 				return nil, jsonrpc2.ErrInvalidParams
 			}
-			return hoverResult{Contents: p.URI + " line " + itoa(p.Line)}, nil
+			return hoverResult{Contents: p.URI + " line " + strconv.Itoa(p.Line)}, nil
 		},
 		"math/sum": func(_ context.Context, params jsonrpc2.RawMessage) (any, error) {
 			var p sumParams
@@ -292,20 +293,4 @@ func TestDownstreamCancel(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("Call never returned")
 	}
-}
-
-// itoa renders a small non-negative int without importing strconv into the test,
-// keeping the shim's surface dependencies minimal.
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	var buf [20]byte
-	i := len(buf)
-	for n > 0 {
-		i--
-		buf[i] = byte('0' + n%10)
-		n /= 10
-	}
-	return string(buf[i:])
 }

--- a/conn.go
+++ b/conn.go
@@ -630,30 +630,26 @@ func (c *conn) readIncoming(ctx context.Context) {
 	var err error
 	for {
 		var (
-			req   RequestMessage
-			msgs  []RequestMessage
-			resp  *Response
-			batch bool
-			rv    Request
-			hasRV bool
+			next nextRead
+			rv   Request
 		)
-		req, msgs, resp, batch, hasRV, err = c.readNext(ctx, &rv)
+		next, err = c.readNext(ctx, &rv)
 		if err != nil {
 			break
 		}
-		if resp != nil {
-			c.deliverResponse(resp)
+		if next.resp != nil {
+			c.deliverResponse(next.resp)
 			continue
 		}
-		if hasRV {
-			if c.handleRequest(ctx, rv) {
+		if next.hasRV {
+			if c.handleRequest(ctx, &rv) {
 				// The handler released itself with Async; a successor reader owns
 				// loop termination from here.
 				return
 			}
 			continue
 		}
-		if c.dispatch(ctx, req, msgs, batch) {
+		if c.dispatch(ctx, next.req, next.msgs, next.batch) {
 			// A handler released itself with Async; a successor reader has taken
 			// over and owns loop termination. Do not run the terminal cleanup.
 			return

--- a/conn.go
+++ b/conn.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -137,6 +138,14 @@ type conn struct {
 	codec     Codec
 	preempter Preempter // optional, consulted before the handler
 
+	// directHandler, when set, dispatches requests through the direct-return
+	// path: the handler's return values become the response, so no per-request
+	// reply closure is allocated. compatHandler adapts it to the closure-based
+	// [Handler] shape for the batch member path, which still funnels replies
+	// through the batch collector.
+	directHandler HandlerV2
+	compatHandler Handler
+
 	done chan struct{} // closed when the connection is fully terminated
 	seq  atomic.Int64  // last allocated outgoing call id
 
@@ -247,6 +256,12 @@ type incomingRequest struct {
 	realCtx    context.Context    // lazily created on first Done
 	realCancel context.CancelFunc // cancels realCtx; nil until realCtx is created
 
+	// reqV2 is the concrete request used by direct-return dispatch. It is a
+	// value field so the request body shares this struct's single allocation;
+	// the handler receives &ir.reqV2 (an interior pointer, no extra alloc).
+	// The v1 interface path leaves it zero and uses req instead.
+	reqV2 RequestV2
+
 	// rel and replied are value fields, not separate heap objects: folding them
 	// into incomingRequest means one dispatch-path allocation (this struct) backs
 	// the request context, the release token, and the replied flag together. The
@@ -317,6 +332,26 @@ func (ir *incomingRequest) Err() error {
 		return context.Canceled
 	default:
 		return ir.parent.Err()
+	}
+}
+
+// cloneRequestOwned replaces the request's borrowed method and params spans
+// with owned copies, in place, so the request remains valid after the read
+// loop reuses the transport frame. It runs at the hard-release (Async) escape
+// point, on the releasing goroutine, strictly before the read loop can read
+// the next frame.
+func (ir *incomingRequest) cloneRequestOwned() {
+	switch m := ir.req.(type) {
+	case *Call:
+		m.method = strings.Clone(m.method)
+		m.params = cloneBytes(m.params)
+	case *Notification:
+		m.method = strings.Clone(m.method)
+		m.params = cloneBytes(m.params)
+	case nil:
+		// Direct-return mode: the concrete request is embedded in ir.
+		ir.reqV2.method = strings.Clone(ir.reqV2.method)
+		ir.reqV2.params = cloneBytes(ir.reqV2.params)
 	}
 }
 
@@ -585,6 +620,29 @@ func (c *conn) Go(ctx context.Context, handler Handler) {
 	go c.readIncoming(ctx, handler)
 }
 
+// goDirect starts the read goroutine in direct-return dispatch mode: h2's
+// return values become the response and no reply closure is allocated per
+// request. The read loop runs with a nil [Handler]; dispatch routes single
+// requests through the direct path and adapts batch members through
+// compatHandler.
+func (c *conn) goDirect(ctx context.Context, h2 HandlerV2) {
+	c.directHandler = h2
+	c.compatHandler = func(ctx context.Context, reply Replier, req Request) error {
+		// Batch members and fallback paths still carry the boxed v1 request;
+		// adapt it to the concrete shape so one handler serves both.
+		rv := RequestV2{method: req.Method(), params: req.Params()}
+		if id, isCall := callID(req); isCall {
+			rv.id, rv.isCall = id, true
+		}
+		result, err := h2(ctx, &rv)
+		return reply(ctx, result, err)
+	}
+	c.updateInFlight(func(s *inFlightState) {
+		s.reading = true
+	})
+	go c.readIncoming(ctx, nil)
+}
+
 // readIncoming is the read goroutine. It reads frames from the stream,
 // correlates responses to waiters, and dispatches requests to the handler until
 // the stream returns an error.
@@ -605,13 +663,23 @@ func (c *conn) readIncoming(ctx context.Context, handler Handler) {
 			msgs  []Request
 			resp  *Response
 			batch bool
+			rv    RequestV2
+			hasRV bool
 		)
-		req, msgs, resp, batch, err = c.readNext(ctx)
+		req, msgs, resp, batch, hasRV, err = c.readNext(ctx, &rv)
 		if err != nil {
 			break
 		}
 		if resp != nil {
 			c.deliverResponse(resp)
+			continue
+		}
+		if hasRV {
+			if c.handleRequestDirect(ctx, rv) {
+				// The direct handler released itself with Async; a successor reader
+				// owns loop termination from here.
+				return
+			}
 			continue
 		}
 		if c.dispatch(ctx, handler, req, msgs, batch) {

--- a/conn.go
+++ b/conn.go
@@ -44,20 +44,28 @@ type Conn interface {
 	// parameters.
 	Notify(ctx context.Context, method string, params any) error
 
-	// Go starts the connection's read goroutine, dispatching incoming requests to
-	// handler. It must be called exactly once per Conn and returns immediately;
-	// block on [Conn.Done] to wait for the connection to terminate.
+	// Go starts the connection's read goroutine, dispatching incoming requests
+	// to handler. It must be called exactly once per Conn and returns
+	// immediately; block on [Conn.Done] to wait for the connection to
+	// terminate.
 	//
-	// By default a request handler runs inline on the read goroutine, so handlers
-	// observe requests in wire order and the next message is not read until the
-	// current handler replies. A handler that wants to overlap later requests
-	// (for example a long-running call, or a server that issues calls back to the
-	// peer) must release itself with [Async] or be wrapped with [AsyncHandler];
-	// otherwise a handler that issues a server-initiated [Conn.Call] back into
-	// this same connection deadlocks the read goroutine, because the response to
-	// that call cannot be read while the read goroutine is blocked running the
-	// handler. A server-initiated [Conn.Notify] needs no release, since it never
-	// waits for a response. See [Handler] for the full reentrancy contract.
+	// Dispatch is direct-return: handler's return values become the response,
+	// no per-request reply machinery is allocated, and the request is a pooled
+	// concrete value whose method and params are borrowed from the transport
+	// frame, valid until the handler returns (see [Handler] for the lifetime
+	// contract and [Request.Clone] for retention).
+	//
+	// By default a request handler runs inline on the read goroutine, so
+	// handlers observe requests in wire order and the next message is not read
+	// until the current handler returns. A handler that wants to overlap later
+	// requests (for example a long-running call, or a server that issues calls
+	// back to the peer) must release itself with [Async] or be wrapped with
+	// [AsyncHandler]; otherwise a handler that issues a server-initiated
+	// [Conn.Call] back into this same connection deadlocks the read goroutine,
+	// because the response to that call cannot be read while the read goroutine
+	// is blocked running the handler. A server-initiated [Conn.Notify] needs no
+	// release, since it never waits for a response. See [Handler] for the full
+	// reentrancy contract.
 	//
 	// [Conn.Close] is the authoritative teardown. Canceling ctx is observed only
 	// between frames: the read loop checks ctx before it starts the next frame, so
@@ -69,16 +77,6 @@ type Conn interface {
 	// canceling ctx is treated as a clean shutdown and is not reported by
 	// [Conn.Err].
 	Go(ctx context.Context, handler Handler)
-
-	// GoDirect starts the connection's read goroutine in direct-return
-	// dispatch mode: handler's return values become the response, no reply
-	// closure is allocated, and the request is a pooled concrete value whose
-	// method and params are borrowed from the transport frame. The borrow is
-	// valid until the handler returns; a handler that retains the request or
-	// releases itself with [Async] must take [RequestV2.Clone] first (Async
-	// clones automatically). Like [Conn.Go], it must be called exactly once
-	// per Conn, and the reentrancy and teardown contracts are identical.
-	GoDirect(ctx context.Context, handler HandlerV2)
 
 	// Close stops accepting new work, waits for in-flight calls and handlers to
 	// drain, closes the underlying stream, and blocks until the connection has
@@ -148,13 +146,10 @@ type conn struct {
 	codec     Codec
 	preempter Preempter // optional, consulted before the handler
 
-	// directHandler, when set, dispatches requests through the direct-return
-	// path: the handler's return values become the response, so no per-request
-	// reply closure is allocated. compatHandler adapts it to the closure-based
-	// [Handler] shape for the batch member path, which still funnels replies
-	// through the batch collector.
-	directHandler HandlerV2
-	compatHandler Handler
+	// handler dispatches every incoming request. It is set once in Go, before
+	// the read goroutine starts, and is nil only on client-only connections
+	// that never receive requests.
+	handler Handler
 
 	done chan struct{} // closed when the connection is fully terminated
 	seq  atomic.Int64  // last allocated outgoing call id
@@ -261,16 +256,14 @@ func putWaiter(w *waiter) {
 // common void path) pays nothing. Deadline and Value delegate to the parent
 // without locking so they stay allocation-free.
 type incomingRequest struct {
-	req        Request
 	parent     context.Context
 	realCtx    context.Context    // lazily created on first Done
 	realCancel context.CancelFunc // cancels realCtx; nil until realCtx is created
 
-	// reqV2 is the concrete request used by direct-return dispatch. It is a
-	// value field so the request body shares this struct's single allocation;
-	// the handler receives &ir.reqV2 (an interior pointer, no extra alloc).
-	// The v1 interface path leaves it zero and uses req instead.
-	reqV2 RequestV2
+	// request is the concrete request being dispatched. It is a value field so
+	// the request body shares this struct's single allocation; the handler
+	// receives &ir.request (an interior pointer, no extra alloc).
+	request Request
 
 	// rel and replied are value fields, not separate heap objects: folding them
 	// into incomingRequest means one dispatch-path allocation (this struct) backs
@@ -351,18 +344,8 @@ func (ir *incomingRequest) Err() error {
 // point, on the releasing goroutine, strictly before the read loop can read
 // the next frame.
 func (ir *incomingRequest) cloneRequestOwned() {
-	switch m := ir.req.(type) {
-	case *Call:
-		m.method = strings.Clone(m.method)
-		m.params = cloneBytes(m.params)
-	case *Notification:
-		m.method = strings.Clone(m.method)
-		m.params = cloneBytes(m.params)
-	case nil:
-		// Direct-return mode: the concrete request is embedded in ir.
-		ir.reqV2.method = strings.Clone(ir.reqV2.method)
-		ir.reqV2.params = cloneBytes(ir.reqV2.params)
-	}
+	ir.request.method = strings.Clone(ir.request.method)
+	ir.request.params = cloneBytes(ir.request.params)
 }
 
 // cancel cancels the request context. If the cancellation channel has not yet
@@ -624,31 +607,11 @@ func (c *conn) afterWrite(ctx context.Context, err error) {
 
 // Go implements [Conn].
 func (c *conn) Go(ctx context.Context, handler Handler) {
+	c.handler = handler
 	c.updateInFlight(func(s *inFlightState) {
 		s.reading = true
 	})
-	go c.readIncoming(ctx, handler)
-}
-
-// GoDirect implements [Conn]. The read loop runs with a nil [Handler];
-// dispatch routes single requests through the direct path and adapts batch
-// members through compatHandler.
-func (c *conn) GoDirect(ctx context.Context, h2 HandlerV2) {
-	c.directHandler = h2
-	c.compatHandler = func(ctx context.Context, reply Replier, req Request) error {
-		// Batch members and fallback paths still carry the boxed v1 request;
-		// adapt it to the concrete shape so one handler serves both.
-		rv := RequestV2{method: req.Method(), params: req.Params()}
-		if id, isCall := callID(req); isCall {
-			rv.id, rv.isCall = id, true
-		}
-		result, err := h2(ctx, &rv)
-		return reply(ctx, result, err)
-	}
-	c.updateInFlight(func(s *inFlightState) {
-		s.reading = true
-	})
-	go c.readIncoming(ctx, nil)
+	go c.readIncoming(ctx)
 }
 
 // readIncoming is the read goroutine. It reads frames from the stream,
@@ -663,15 +626,15 @@ func (c *conn) GoDirect(ctx context.Context, h2 HandlerV2) {
 // reader to own loop termination. The reader role is therefore held by exactly
 // one goroutine at a time, and the terminal cleanup below runs exactly once: on
 // the goroutine that breaks the loop on a read error, never on a handed-off one.
-func (c *conn) readIncoming(ctx context.Context, handler Handler) {
+func (c *conn) readIncoming(ctx context.Context) {
 	var err error
 	for {
 		var (
-			req   Request
-			msgs  []Request
+			req   RequestMessage
+			msgs  []RequestMessage
 			resp  *Response
 			batch bool
-			rv    RequestV2
+			rv    Request
 			hasRV bool
 		)
 		req, msgs, resp, batch, hasRV, err = c.readNext(ctx, &rv)
@@ -683,16 +646,16 @@ func (c *conn) readIncoming(ctx context.Context, handler Handler) {
 			continue
 		}
 		if hasRV {
-			if c.handleRequestDirect(ctx, rv) {
-				// The direct handler released itself with Async; a successor reader
-				// owns loop termination from here.
+			if c.handleRequest(ctx, rv) {
+				// The handler released itself with Async; a successor reader owns
+				// loop termination from here.
 				return
 			}
 			continue
 		}
-		if c.dispatch(ctx, handler, req, msgs, batch) {
-			// An inline handler released itself with Async; a successor reader has
-			// taken over and owns loop termination. Do not run the terminal cleanup.
+		if c.dispatch(ctx, req, msgs, batch) {
+			// A handler released itself with Async; a successor reader has taken
+			// over and owns loop termination. Do not run the terminal cleanup.
 			return
 		}
 	}

--- a/conn.go
+++ b/conn.go
@@ -70,6 +70,16 @@ type Conn interface {
 	// [Conn.Err].
 	Go(ctx context.Context, handler Handler)
 
+	// GoDirect starts the connection's read goroutine in direct-return
+	// dispatch mode: handler's return values become the response, no reply
+	// closure is allocated, and the request is a pooled concrete value whose
+	// method and params are borrowed from the transport frame. The borrow is
+	// valid until the handler returns; a handler that retains the request or
+	// releases itself with [Async] must take [RequestV2.Clone] first (Async
+	// clones automatically). Like [Conn.Go], it must be called exactly once
+	// per Conn, and the reentrancy and teardown contracts are identical.
+	GoDirect(ctx context.Context, handler HandlerV2)
+
 	// Close stops accepting new work, waits for in-flight calls and handlers to
 	// drain, closes the underlying stream, and blocks until the connection has
 	// fully terminated (the read goroutine has exited). It reports the stream's
@@ -620,12 +630,10 @@ func (c *conn) Go(ctx context.Context, handler Handler) {
 	go c.readIncoming(ctx, handler)
 }
 
-// goDirect starts the read goroutine in direct-return dispatch mode: h2's
-// return values become the response and no reply closure is allocated per
-// request. The read loop runs with a nil [Handler]; dispatch routes single
-// requests through the direct path and adapts batch members through
-// compatHandler.
-func (c *conn) goDirect(ctx context.Context, h2 HandlerV2) {
+// GoDirect implements [Conn]. The read loop runs with a nil [Handler];
+// dispatch routes single requests through the direct path and adapts batch
+// members through compatHandler.
+func (c *conn) GoDirect(ctx context.Context, h2 HandlerV2) {
 	c.directHandler = h2
 	c.compatHandler = func(ctx context.Context, reply Replier, req Request) error {
 		// Batch members and fallback paths still carry the boxed v1 request;

--- a/conn_test.go
+++ b/conn_test.go
@@ -813,7 +813,8 @@ func TestConnReadNextDirectUnmarshalResult(t *testing.T) {
 	w := getWaiter(&got)
 	c.state.outgoingCalls.Add(NewNumberID(7), w)
 
-	req, msgs, resp, batch, err := c.readNext(ctx)
+	req, msgs, resp, batch, hasRV, err := c.readNext(ctx, new(RequestV2))
+	_ = hasRV
 	if err != nil {
 		t.Fatalf("readNext error: %v", err)
 	}
@@ -865,7 +866,8 @@ func TestConnReadNextDirectUnmarshalSkipsLargeResult(t *testing.T) {
 	w := getWaiter(&got)
 	c.state.outgoingCalls.Add(NewNumberID(9), w)
 
-	req, msgs, resp, batch, err := c.readNext(ctx)
+	req, msgs, resp, batch, hasRV, err := c.readNext(ctx, new(RequestV2))
+	_ = hasRV
 	if err != nil {
 		t.Fatalf("readNext error: %v", err)
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -97,21 +97,21 @@ type echoHandler struct {
 	recorded []string
 }
 
-func (h *echoHandler) handle(ctx context.Context, reply Replier, req Request) error {
+func (h *echoHandler) handle(ctx context.Context, req *Request) (any, error) {
 	switch req.Method() {
 	case "echo":
-		return reply(ctx, raw(`{"got":`+string(orNull(req.Params()))+`}`), nil)
+		return raw(`{"got":` + string(orNull(req.Params())) + `}`), nil
 	case "fail":
-		return reply(ctx, nil, NewError(InvalidParams, "bad params"))
+		return nil, NewError(InvalidParams, "bad params")
 	case "marshal-fail":
-		return reply(ctx, make(chan int), nil)
+		return make(chan int), nil
 	case "note":
 		h.mu.Lock()
 		h.recorded = append(h.recorded, string(orNull(req.Params())))
 		h.mu.Unlock()
-		return reply(ctx, nil, nil)
+		return nil, nil
 	default:
-		return MethodNotFoundHandler(ctx, reply, req)
+		return MethodNotFoundHandler(ctx, req)
 	}
 }
 
@@ -230,14 +230,14 @@ func TestCancelPropagatesToHandler(t *testing.T) {
 	handlerErr := make(chan error, 1)
 	// CancelHandler exposes a canceller keyed by id; AsyncHandler frees the read
 	// loop so the cancel notification can be observed while the call is blocked.
-	base := func(ctx context.Context, reply Replier, req Request) error {
+	base := func(ctx context.Context, req *Request) (any, error) {
 		if req.Method() == "block" {
 			close(started)
 			<-ctx.Done()
 			handlerErr <- ctx.Err()
-			return reply(ctx, nil, ctx.Err())
+			return nil, ctx.Err()
 		}
-		return reply(ctx, nil, nil)
+		return nil, nil
 	}
 	h, canceller := CancelHandler(AsyncHandler(base))
 	server := NewConn(eb.stream)
@@ -273,9 +273,9 @@ func TestClientContextCancelStopsWaiting(t *testing.T) {
 	release := make(chan struct{})
 	server := NewConn(eb.stream)
 	client.Go(ctx, MethodNotFoundHandler)
-	server.Go(ctx, AsyncHandler(func(ctx context.Context, reply Replier, req Request) error {
+	server.Go(ctx, AsyncHandler(func(ctx context.Context, req *Request) (any, error) {
 		<-release
-		return reply(ctx, nil, nil)
+		return nil, nil
 	}))
 	defer closeBoth(t, client, server)
 	defer close(release)
@@ -309,18 +309,19 @@ func TestCanceledCallLateResponseDoesNotReachLaterCall(t *testing.T) {
 	slowReplied := make(chan error, 1)
 	server := NewConn(eb.stream)
 	client.Go(ctx, MethodNotFoundHandler)
-	server.Go(ctx, AsyncHandler(func(ctx context.Context, reply Replier, req Request) error {
+	server.Go(ctx, AsyncHandler(func(ctx context.Context, req *Request) (any, error) {
 		switch req.Method() {
 		case "slow":
 			close(slowStarted)
 			<-slowRelease
-			err := reply(ctx, "late", nil)
-			slowReplied <- err
-			return err
+			// The direct shape sends the late response after return; the channel
+			// send keeps the test's ordering observable.
+			slowReplied <- nil
+			return "late", nil
 		case "fast":
-			return reply(ctx, "fast", nil)
+			return "fast", nil
 		default:
-			return reply(ctx, nil, ErrMethodNotFound)
+			return nil, ErrMethodNotFound
 		}
 	}))
 	defer closeBoth(t, client, server)
@@ -380,8 +381,8 @@ func TestGracefulClose(t *testing.T) {
 			client := NewConn(ea.stream)
 			server := NewConn(eb.stream)
 			client.Go(ctx, MethodNotFoundHandler)
-			server.Go(ctx, func(ctx context.Context, reply Replier, req Request) error {
-				return reply(ctx, "ok", nil)
+			server.Go(ctx, func(ctx context.Context, req *Request) (any, error) {
+				return "ok", nil
 			})
 
 			var s string
@@ -423,8 +424,8 @@ func TestGracefulClose(t *testing.T) {
 func TestSyncAsyncParity(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	base := func(ctx context.Context, reply Replier, req Request) error {
-		return reply(ctx, raw(`{"n":`+string(orNull(req.Params()))+`}`), nil)
+	base := func(ctx context.Context, req *Request) (any, error) {
+		return raw(`{"n":` + string(orNull(req.Params())) + `}`), nil
 	}
 
 	modes := map[string]Handler{
@@ -468,7 +469,7 @@ func TestAsyncRunsConcurrently(t *testing.T) {
 
 	server := NewConn(eb.stream)
 	client.Go(ctx, MethodNotFoundHandler)
-	server.Go(ctx, AsyncHandler(func(ctx context.Context, reply Replier, req Request) error {
+	server.Go(ctx, AsyncHandler(func(ctx context.Context, req *Request) (any, error) {
 		cur := inFlight.Add(1)
 		for {
 			old := maxConcurrent.Load()
@@ -478,7 +479,7 @@ func TestAsyncRunsConcurrently(t *testing.T) {
 		}
 		<-gate // hold until all are in flight
 		inFlight.Add(-1)
-		return reply(ctx, nil, nil)
+		return nil, nil
 	}))
 	defer closeBoth(t, client, server)
 
@@ -511,8 +512,8 @@ func TestConcurrencyStress(t *testing.T) {
 	client.Go(ctx, MethodNotFoundHandler)
 	// The server echoes the numeric params back as the result so each response
 	// can be verified against the request that produced it.
-	server.Go(ctx, AsyncHandler(func(ctx context.Context, reply Replier, req Request) error {
-		return reply(ctx, raw(string(orNull(req.Params()))), nil)
+	server.Go(ctx, AsyncHandler(func(ctx context.Context, req *Request) (any, error) {
+		return raw(string(orNull(req.Params()))), nil
 	}))
 	defer closeBoth(t, client, server)
 
@@ -555,8 +556,8 @@ func TestGoroutineLeak(t *testing.T) {
 		client := NewConn(ea.stream)
 		server := NewConn(eb.stream)
 		client.Go(ctx, MethodNotFoundHandler)
-		server.Go(ctx, AsyncHandler(func(ctx context.Context, reply Replier, req Request) error {
-			return reply(ctx, "ok", nil)
+		server.Go(ctx, AsyncHandler(func(ctx context.Context, req *Request) (any, error) {
+			return "ok", nil
 		}))
 		for range 5 {
 			var s string
@@ -599,10 +600,10 @@ func TestCloseDrainsInFlight(t *testing.T) {
 	// The handler is released for concurrent handling so the read loop is free,
 	// then it parks until the test releases it: the request is genuinely in flight
 	// while Close is called.
-	server.Go(ctx, AsyncHandler(func(ctx context.Context, reply Replier, req Request) error {
+	server.Go(ctx, AsyncHandler(func(ctx context.Context, req *Request) (any, error) {
 		close(started)
 		<-release
-		return reply(ctx, "done", nil)
+		return "done", nil
 	}))
 
 	// The parked call's response is not guaranteed to flush once the server starts
@@ -658,9 +659,9 @@ type recordingPreempter struct {
 	seen []string
 }
 
-func (p *recordingPreempter) Preempt(ctx context.Context, req Request) (any, error) {
+func (p *recordingPreempter) Preempt(ctx context.Context, req *Request) (any, error) {
 	p.mu.Lock()
-	p.seen = append(p.seen, req.Method())
+	p.seen = append(p.seen, strings.Clone(req.Method()))
 	p.mu.Unlock()
 	if req.Method() == "preempt" {
 		return raw(`"preempted"`), nil
@@ -684,11 +685,11 @@ func TestPreempter(t *testing.T) {
 	var handlerSawPreempt atomic.Bool
 	server := NewConn(eb.stream, WithPreempter(pre))
 	client.Go(ctx, MethodNotFoundHandler)
-	server.Go(ctx, func(ctx context.Context, reply Replier, req Request) error {
+	server.Go(ctx, func(ctx context.Context, req *Request) (any, error) {
 		if req.Method() == "preempt" {
 			handlerSawPreempt.Store(true)
 		}
-		return reply(ctx, raw(`"handled"`), nil)
+		return raw(`"handled"`), nil
 	})
 	defer closeBoth(t, client, server)
 
@@ -763,8 +764,8 @@ func TestCloseRacesConcurrentWrites(t *testing.T) {
 		server := NewConn(eb.stream)
 		ctx, cancel := context.WithCancel(t.Context())
 		client.Go(ctx, MethodNotFoundHandler)
-		server.Go(ctx, func(ctx context.Context, reply Replier, req Request) error {
-			return reply(ctx, nil, nil)
+		server.Go(ctx, func(ctx context.Context, req *Request) (any, error) {
+			return nil, nil
 		})
 
 		// Drive a burst of concurrent writers; some will race the Close.
@@ -813,7 +814,7 @@ func TestConnReadNextDirectUnmarshalResult(t *testing.T) {
 	w := getWaiter(&got)
 	c.state.outgoingCalls.Add(NewNumberID(7), w)
 
-	req, msgs, resp, batch, hasRV, err := c.readNext(ctx, new(RequestV2))
+	req, msgs, resp, batch, hasRV, err := c.readNext(ctx, new(Request))
 	_ = hasRV
 	if err != nil {
 		t.Fatalf("readNext error: %v", err)
@@ -866,7 +867,7 @@ func TestConnReadNextDirectUnmarshalSkipsLargeResult(t *testing.T) {
 	w := getWaiter(&got)
 	c.state.outgoingCalls.Add(NewNumberID(9), w)
 
-	req, msgs, resp, batch, hasRV, err := c.readNext(ctx, new(RequestV2))
+	req, msgs, resp, batch, hasRV, err := c.readNext(ctx, new(Request))
 	_ = hasRV
 	if err != nil {
 		t.Fatalf("readNext error: %v", err)

--- a/conn_test.go
+++ b/conn_test.go
@@ -814,13 +814,12 @@ func TestConnReadNextDirectUnmarshalResult(t *testing.T) {
 	w := getWaiter(&got)
 	c.state.outgoingCalls.Add(NewNumberID(7), w)
 
-	req, msgs, resp, batch, hasRV, err := c.readNext(ctx, new(Request))
-	_ = hasRV
+	next, err := c.readNext(ctx, new(Request))
 	if err != nil {
 		t.Fatalf("readNext error: %v", err)
 	}
-	if req != nil || msgs != nil || resp != nil || batch {
-		t.Fatalf("readNext = req %T, msgs %d, resp %T, batch %v; want delivered response", req, len(msgs), resp, batch)
+	if next.req != nil || next.msgs != nil || next.resp != nil || next.batch || next.hasRV {
+		t.Fatalf("readNext = req %T, msgs %d, resp %T, batch %v, hasRV %v; want delivered response", next.req, len(next.msgs), next.resp, next.batch, next.hasRV)
 	}
 
 	select {
@@ -867,16 +866,15 @@ func TestConnReadNextDirectUnmarshalSkipsLargeResult(t *testing.T) {
 	w := getWaiter(&got)
 	c.state.outgoingCalls.Add(NewNumberID(9), w)
 
-	req, msgs, resp, batch, hasRV, err := c.readNext(ctx, new(Request))
-	_ = hasRV
+	next, err := c.readNext(ctx, new(Request))
 	if err != nil {
 		t.Fatalf("readNext error: %v", err)
 	}
-	if req != nil || msgs != nil || resp == nil || batch {
-		t.Fatalf("readNext = req %T, msgs %d, resp %T, batch %v; want owned response fallback", req, len(msgs), resp, batch)
+	if next.req != nil || next.msgs != nil || next.resp == nil || next.batch || next.hasRV {
+		t.Fatalf("readNext = req %T, msgs %d, resp %T, batch %v, hasRV %v; want owned response fallback", next.req, len(next.msgs), next.resp, next.batch, next.hasRV)
 	}
-	if len(resp.result) <= maxConnDirectUnmarshalResult {
-		t.Fatalf("response result len = %d, want > %d", len(resp.result), maxConnDirectUnmarshalResult)
+	if len(next.resp.result) <= maxConnDirectUnmarshalResult {
+		t.Fatalf("response result len = %d, want > %d", len(next.resp.result), maxConnDirectUnmarshalResult)
 	}
 	select {
 	case <-w.ready:

--- a/dispatch.go
+++ b/dispatch.go
@@ -124,13 +124,102 @@ func (c *conn) handleRequest(ctx context.Context, handler Handler, req Request) 
 	// The inline releaser carries the state for the Async handoff in typed fields
 	// (ch left nil). It is a value field of ir, so initializing it in place adds no
 	// allocation beyond ir itself.
-	ir.rel = releaser{active: true, conn: c, ctx: ctx, handler: handler}
+	ir.rel = releaser{active: true, conn: c, ctx: ctx, handler: handler, ir: ir}
 
 	reply, replied := c.replier(ir, nil)
 	c.runHandler(handler, ir, &ir.rel, reply, replied)
 	// handedOff is set by a hard release (Async) on this same read goroutine
 	// before runHandler returns, so the read carries no data race.
 	return ir.rel.handedOff
+}
+
+// setupRequestV2 registers a scanned concrete request as in-flight. It mirrors
+// setupRequest for the direct-return path: the request value is embedded in
+// the incomingRequest rather than boxed behind the v1 interface, and the
+// incomingRequest itself comes from the request pool. The optional Preempter
+// is not consulted on this path; direct mode is the v2 surface.
+func (c *conn) setupRequestV2(ctx context.Context, rv RequestV2) (ir *incomingRequest, done bool) {
+	ir = getIncomingRequest()
+	ir.parent = ctx
+	ir.id = rv.id
+	ir.isCall = rv.isCall
+	ir.reqV2 = rv
+
+	var shutErr error
+	c.updateInFlight(func(s *inFlightState) {
+		s.incoming++
+		if rv.isCall {
+			if s.incomingByID == nil {
+				s.incomingByID = make(map[ID]*incomingRequest)
+			}
+			s.incomingByID[rv.id] = ir
+			shutErr = s.shuttingDown(ErrServerClosing)
+		}
+	})
+
+	if shutErr != nil {
+		if ir.isCall && ir.replied.done.CompareAndSwap(false, true) {
+			_ = c.sendResponse(ir, ir.id, nil, nil, shutErr)
+		}
+		c.afterHandle(ir)
+		return nil, true
+	}
+
+	return ir, false
+}
+
+// handleRequestDirect dispatches a single (non-batch) incoming request through
+// the direct-return path: the handler's return values are sent as the response
+// directly, so no reply closure is allocated and no message box exists. The
+// duplicate-reply guard lives on ir.replied exactly as in the closure path,
+// shared with the panic fallback.
+func (c *conn) handleRequestDirect(ctx context.Context, rv RequestV2) (handedOff bool) {
+	ir, done := c.setupRequestV2(ctx, rv)
+	if done {
+		return false
+	}
+
+	// The successor handler is nil: a hard release (Async) hands the reader role
+	// to a fresh readIncoming with a nil handler, which keeps direct dispatch.
+	ir.rel = releaser{active: true, conn: c, ctx: ctx, ir: ir}
+
+	c.runHandlerDirect(ir)
+	return ir.rel.handedOff
+}
+
+// runHandlerDirect invokes the direct-return handler and answers the request
+// from its return values. The deferred recover answers an unanswered call and
+// fails the connection on panic, mirroring runHandler.
+//
+// The pool put is registered first so it runs last, strictly after afterHandle
+// has finished the request's bookkeeping. A hard-released (Async) request is
+// never pooled: its lifetime escaped the dispatch path, and a handler that
+// detached may legally hold the request until it returns on its own schedule.
+func (c *conn) runHandlerDirect(ir *incomingRequest) {
+	defer putIncomingRequestUnlessDetached(ir)
+	defer c.afterHandle(ir)
+	defer ir.rel.release(true)
+	defer func() {
+		if r := recover(); r != nil {
+			if ir.isCall && ir.replied.done.CompareAndSwap(false, true) {
+				_ = c.sendResponse(ir, ir.id, nil, nil, Errorf(InternalError, "jsonrpc2: handler panicked: %v", r))
+			}
+			c.fail(fmt.Errorf("jsonrpc2: handler for %q panicked: %v", ir.reqV2.method, r))
+		}
+	}()
+
+	result, err := c.directHandler(ir, &ir.reqV2)
+	if !ir.isCall {
+		// A notification has no response; a handler error is a connection-level
+		// failure, matching the closure path's contract.
+		if err != nil {
+			c.fail(err)
+		}
+		return
+	}
+	if ir.replied.done.CompareAndSwap(false, true) {
+		_ = c.sendResponse(ir, ir.id, nil, result, err)
+	}
 }
 
 // handleBatchMember dispatches one batch member. Unlike the inline
@@ -144,7 +233,7 @@ func (c *conn) handleBatchMember(ctx context.Context, handler Handler, req Reque
 		return
 	}
 
-	ir.rel = releaser{active: true, ch: make(chan struct{})}
+	ir.rel = releaser{active: true, ch: make(chan struct{}), ir: ir}
 
 	reply, replied := c.replier(ir, bc)
 

--- a/dispatch.go
+++ b/dispatch.go
@@ -184,19 +184,24 @@ func (c *conn) handleRequestDirect(ctx context.Context, rv RequestV2) (handedOff
 	ir.rel = releaser{active: true, conn: c, ctx: ctx, ir: ir}
 
 	c.runHandlerDirect(ir)
-	return ir.rel.handedOff
+
+	// The pool put is the LAST touch on ir: it must come after the handedOff
+	// read, because the instant ir is pooled another reader can recycle it and
+	// overwrite ir.rel. A hard-released (Async) request is never pooled -- its
+	// lifetime escaped the dispatch path and a detached handler may legally
+	// hold it until it returns on its own schedule.
+	handedOff = ir.rel.handedOff
+	if !handedOff {
+		putIncomingRequest(ir)
+	}
+	return handedOff
 }
 
 // runHandlerDirect invokes the direct-return handler and answers the request
 // from its return values. The deferred recover answers an unanswered call and
-// fails the connection on panic, mirroring runHandler.
-//
-// The pool put is registered first so it runs last, strictly after afterHandle
-// has finished the request's bookkeeping. A hard-released (Async) request is
-// never pooled: its lifetime escaped the dispatch path, and a handler that
-// detached may legally hold the request until it returns on its own schedule.
+// fails the connection on panic, mirroring runHandler. The caller owns the
+// pool put (after its final read of ir), so ir is fully alive throughout.
 func (c *conn) runHandlerDirect(ir *incomingRequest) {
-	defer putIncomingRequestUnlessDetached(ir)
 	defer c.afterHandle(ir)
 	defer ir.rel.release(true)
 	defer func() {

--- a/dispatch.go
+++ b/dispatch.go
@@ -219,10 +219,11 @@ func (c *conn) runBatchMember(ir *incomingRequest, bc *batchCollector) {
 	}
 }
 
-// repliedFlag reports whether a request has been answered. It is shared
-// between the handler path (which answers from return values or the panic
-// fallback) and the complete path, so it is backed by an atomic to make the
-// first-answer race deterministic.
+// repliedFlag reports whether a request has been answered. Direct-return
+// dispatch answers in exactly one place per path, but an [Async]-detached
+// handler returns (and answers) on its own goroutine while connection
+// shutdown can answer the same call from another, so the first-answer claim
+// stays an atomic CAS rather than a plain bool.
 type repliedFlag struct {
 	done atomic.Bool
 }

--- a/dispatch.go
+++ b/dispatch.go
@@ -32,12 +32,12 @@ func requestValue(req RequestMessage) Request {
 // done=true when the request has already been fully answered (preempted, or a
 // call rejected because the connection is shutting down), in which case the
 // caller must not invoke the handler.
-func (c *conn) setupRequest(ctx context.Context, rv Request, bc *batchCollector) (ir *incomingRequest, done bool) {
+func (c *conn) setupRequest(ctx context.Context, rv *Request, bc *batchCollector) (ir *incomingRequest, done bool) {
 	ir = getIncomingRequest()
 	ir.parent = ctx
 	ir.id = rv.id
 	ir.isCall = rv.isCall
-	ir.request = rv
+	ir.request = *rv
 
 	// A Preempter, if configured, runs inline on the read goroutine before the
 	// request is dispatched. ErrNotHandled or a nil handled value defers to the
@@ -139,7 +139,7 @@ func (c *conn) runHandler(ir *incomingRequest, bc *batchCollector) {
 // handleRequest then reports it so the current read loop returns while this
 // goroutine finishes the handler concurrently. The successor reader owns loop
 // termination, so the reader role is always held by exactly one goroutine.
-func (c *conn) handleRequest(ctx context.Context, rv Request) (handedOff bool) {
+func (c *conn) handleRequest(ctx context.Context, rv *Request) (handedOff bool) {
 	ir, done := c.setupRequest(ctx, rv, nil)
 	if done {
 		return false
@@ -173,7 +173,8 @@ func (c *conn) handleBoxedRequest(ctx context.Context, req RequestMessage) (hand
 		c.writeInvalid(ctx, nil, inv.err)
 		return false
 	}
-	return c.handleRequest(ctx, requestValue(req))
+	rv := requestValue(req)
+	return c.handleRequest(ctx, &rv)
 }
 
 // handleBatchMember dispatches one batch member. Unlike the inline
@@ -189,7 +190,8 @@ func (c *conn) handleBatchMember(ctx context.Context, req RequestMessage, bc *ba
 		return
 	}
 
-	ir, done := c.setupRequest(ctx, requestValue(req), bc)
+	rv := requestValue(req)
+	ir, done := c.setupRequest(ctx, &rv, bc)
 	if done {
 		return
 	}

--- a/dispatch.go
+++ b/dispatch.go
@@ -10,140 +10,46 @@ import (
 	"sync/atomic"
 )
 
-// setupRequest registers req as in-flight and returns the per-request context.
-// It returns done=true when the request has already been fully answered (a
-// malformed batch member, a preempted request, or a call rejected because the
-// connection is shutting down), in which case the caller must not invoke the
-// handler.
-func (c *conn) setupRequest(ctx context.Context, req Request, bc *batchCollector) (ir *incomingRequest, done bool) {
-	if inv, ok := req.(*invalidRequest); ok {
-		// A malformed batch member never reaches the handler; answer it directly
-		// with a null-id error response so the valid members are still served.
-		c.writeInvalid(ctx, bc, inv.err)
-		return nil, true
-	}
-
-	id, isCall := callID(req)
-	ir = &incomingRequest{req: req, parent: ctx, id: id, isCall: isCall}
-
-	// A Preempter, if configured, runs inline on the read goroutine before the
-	// request is queued for the handler. ErrNotHandled or a nil handled value
-	// defers to the handler; every other result or error is answered here.
-	if c.preempter != nil {
-		result, perr := c.preempter.Preempt(ir, req)
-		if !errors.Is(perr, ErrNotHandled) && (result != nil || perr != nil) {
-			c.updateInFlight(func(s *inFlightState) { s.incoming++ })
-			c.completeRequest(ir, ir, bc, result, perr)
-			return nil, true
-		}
-	}
-
-	var shutErr error
-	c.updateInFlight(func(s *inFlightState) {
-		s.incoming++
-		if isCall {
-			if s.incomingByID == nil {
-				s.incomingByID = make(map[ID]*incomingRequest)
-			}
-			s.incomingByID[id] = ir
-			shutErr = s.shuttingDown(ErrServerClosing)
-		}
-	})
-
-	if shutErr != nil {
-		// Reject a call that arrived while shutting down with an immediate error
-		// response, and account for it so the connection can reach idle.
-		c.completeRequest(ir, ir, bc, nil, shutErr)
-		return nil, true
-	}
-
-	return ir, false
-}
-
-// runHandler invokes handler for the request, sending its reply and performing
-// the request-scoped cleanup through defers so that a panic cannot leak the
-// in-flight counter or the incomingByID entry and deadlock a later Close.
-//
-// Defers run last-in-first-out: the recover defer (registered last) runs first,
-// then the release (the dispatch path's idempotent soft release), then
-// afterHandle (registered first) runs last so the in-flight counter is
-// decremented only after the response is sent and the read loop is released. It
-// is shared by the inline single-message path and the batch-member goroutine.
-func (c *conn) runHandler(handler Handler, ir *incomingRequest, rel *releaser, reply Replier, replied *repliedFlag) {
-	req := ir.req
-	defer c.afterHandle(ir)
-	// release(true) is the soft release that frees the read loop in the
-	// synchronous case (when the handler did not call Async) and after a panic.
-	// It is idempotent, so a request that already released early via Async is
-	// unaffected.
-	defer rel.release(true)
-	defer func() {
-		if r := recover(); r != nil {
-			// A handler panic is a request-scoped failure, not a process-wide one:
-			// answer an unanswered call with an internal error so the caller (and
-			// any batch flush awaiting this member) is not left hanging, then fail
-			// the connection so the panic is surfaced rather than silently swallowed.
-			if !replied.value() {
-				_ = reply(ir, nil, Errorf(InternalError, "jsonrpc2: handler panicked: %v", r))
-			}
-			c.fail(fmt.Errorf("jsonrpc2: handler for %q panicked: %v", req.Method(), r))
-		}
-	}()
-
-	err := handler(ir, reply, req)
-	if err != nil {
-		// A handler-returned error is a connection-level failure: fail the
-		// connection so it tears down rather than silently dropping the error.
-		c.fail(err)
-	}
-	// A handler that returns for a call without replying would otherwise leave the
-	// caller (and any batch flush awaiting this member) hanging forever. Guarantee
-	// a deterministic outcome by answering with an internal error.
-	if !replied.value() {
-		_ = reply(ir, nil, Errorf(InternalError, "jsonrpc2: handler for %q returned without replying", req.Method()))
+// requestValue converts a boxed wire request (a batch member or a
+// single-message fallback) into the concrete dispatch shape. The spans keep
+// borrowing whatever the box borrowed; ownership questions are settled by the
+// release path exactly as for scanned requests.
+func requestValue(req RequestMessage) Request {
+	switch m := req.(type) {
+	case *Call:
+		return Request{id: m.id, method: m.method, params: m.params, isCall: true}
+	case *Notification:
+		return Request{method: m.method, params: m.params}
+	default:
+		// invalidRequest never reaches here; the dispatch paths answer it
+		// before conversion.
+		return Request{}
 	}
 }
 
-// handleRequest dispatches a single (non-batch) incoming request inline on the
-// read goroutine. The handler runs to completion on this goroutine in the
-// common synchronous case, so it spawns no goroutine and handlers observe
-// requests in wire order.
-//
-// When the handler releases itself with [Async], the release effect spawns a
-// fresh read goroutine to take over the reader role and records the handoff on
-// the releaser; handleRequest then reports it so the current read loop returns
-// while this goroutine finishes the handler concurrently. The successor reader
-// owns loop termination, so the reader role is always held by exactly one
-// goroutine.
-func (c *conn) handleRequest(ctx context.Context, handler Handler, req Request) (handedOff bool) {
-	ir, done := c.setupRequest(ctx, req, nil)
-	if done {
-		return false
-	}
-
-	// The inline releaser carries the state for the Async handoff in typed fields
-	// (ch left nil). It is a value field of ir, so initializing it in place adds no
-	// allocation beyond ir itself.
-	ir.rel = releaser{active: true, conn: c, ctx: ctx, handler: handler, ir: ir}
-
-	reply, replied := c.replier(ir, nil)
-	c.runHandler(handler, ir, &ir.rel, reply, replied)
-	// handedOff is set by a hard release (Async) on this same read goroutine
-	// before runHandler returns, so the read carries no data race.
-	return ir.rel.handedOff
-}
-
-// setupRequestV2 registers a scanned concrete request as in-flight. It mirrors
-// setupRequest for the direct-return path: the request value is embedded in
-// the incomingRequest rather than boxed behind the v1 interface, and the
-// incomingRequest itself comes from the request pool. The optional Preempter
-// is not consulted on this path; direct mode is the v2 surface.
-func (c *conn) setupRequestV2(ctx context.Context, rv RequestV2) (ir *incomingRequest, done bool) {
+// setupRequest takes a pooled incomingRequest, fills it from rv, consults the
+// optional Preempter, and registers the request as in-flight. It returns
+// done=true when the request has already been fully answered (preempted, or a
+// call rejected because the connection is shutting down), in which case the
+// caller must not invoke the handler.
+func (c *conn) setupRequest(ctx context.Context, rv Request, bc *batchCollector) (ir *incomingRequest, done bool) {
 	ir = getIncomingRequest()
 	ir.parent = ctx
 	ir.id = rv.id
 	ir.isCall = rv.isCall
-	ir.reqV2 = rv
+	ir.request = rv
+
+	// A Preempter, if configured, runs inline on the read goroutine before the
+	// request is dispatched. ErrNotHandled or a nil handled value defers to the
+	// handler; every other result or error is answered here.
+	if c.preempter != nil {
+		result, perr := c.preempter.Preempt(ir, &ir.request)
+		if !errors.Is(perr, ErrNotHandled) && (result != nil || perr != nil) {
+			c.updateInFlight(func(s *inFlightState) { s.incoming++ })
+			c.completeRequest(ir, bc, result, perr)
+			return nil, true
+		}
+	}
 
 	var shutErr error
 	c.updateInFlight(func(s *inFlightState) {
@@ -158,143 +64,167 @@ func (c *conn) setupRequestV2(ctx context.Context, rv RequestV2) (ir *incomingRe
 	})
 
 	if shutErr != nil {
-		if ir.isCall && ir.replied.done.CompareAndSwap(false, true) {
-			_ = c.sendResponse(ir, ir.id, nil, nil, shutErr)
-		}
-		c.afterHandle(ir)
+		// Reject a call that arrived while shutting down with an immediate error
+		// response, and account for it so the connection can reach idle.
+		c.completeRequest(ir, bc, nil, shutErr)
 		return nil, true
 	}
 
 	return ir, false
 }
 
-// handleRequestDirect dispatches a single (non-batch) incoming request through
-// the direct-return path: the handler's return values are sent as the response
-// directly, so no reply closure is allocated and no message box exists. The
-// duplicate-reply guard lives on ir.replied exactly as in the closure path,
-// shared with the panic fallback.
-func (c *conn) handleRequestDirect(ctx context.Context, rv RequestV2) (handedOff bool) {
-	ir, done := c.setupRequestV2(ctx, rv)
-	if done {
-		return false
+// completeRequest answers a request without invoking the handler (a preempted
+// request or one rejected during shutdown), releases its bookkeeping, and
+// recycles it.
+func (c *conn) completeRequest(ir *incomingRequest, bc *batchCollector, result any, err error) {
+	if ir.isCall && ir.replied.done.CompareAndSwap(false, true) {
+		_ = c.sendResponse(ir, ir.id, bc, result, err)
 	}
-
-	// The successor handler is nil: a hard release (Async) hands the reader role
-	// to a fresh readIncoming with a nil handler, which keeps direct dispatch.
-	ir.rel = releaser{active: true, conn: c, ctx: ctx, ir: ir}
-
-	c.runHandlerDirect(ir)
-
-	// The pool put is the LAST touch on ir: it must come after the handedOff
-	// read, because the instant ir is pooled another reader can recycle it and
-	// overwrite ir.rel. A hard-released (Async) request is never pooled -- its
-	// lifetime escaped the dispatch path and a detached handler may legally
-	// hold it until it returns on its own schedule.
-	handedOff = ir.rel.handedOff
-	if !handedOff {
-		putIncomingRequest(ir)
-	}
-	return handedOff
+	c.afterHandle(ir)
+	putIncomingRequest(ir)
 }
 
-// runHandlerDirect invokes the direct-return handler and answers the request
-// from its return values. The deferred recover answers an unanswered call and
-// fails the connection on panic, mirroring runHandler. The caller owns the
-// pool put (after its final read of ir), so ir is fully alive throughout.
-func (c *conn) runHandlerDirect(ir *incomingRequest) {
+// runHandler invokes the handler and answers the request from its return
+// values, performing the request-scoped cleanup through defers so that a
+// panic cannot leak the in-flight counter or the incomingByID entry and
+// deadlock a later Close.
+//
+// Defers run last-in-first-out: the recover defer (registered last) runs
+// first and answers an unanswered call, then the soft release frees the read
+// loop (or the batch dispatch loop), then afterHandle decrements the
+// in-flight counter. The caller owns the pool put, after its final read of
+// ir's release flags.
+func (c *conn) runHandler(ir *incomingRequest, bc *batchCollector) {
 	defer c.afterHandle(ir)
+	// release(true) is the soft release that frees the read loop in the
+	// synchronous case (when the handler did not call Async) and after a panic.
+	// It is idempotent, so a request that already released early via Async is
+	// unaffected.
 	defer ir.rel.release(true)
 	defer func() {
 		if r := recover(); r != nil {
+			// A handler panic is a request-scoped failure, not a process-wide one:
+			// answer an unanswered call with an internal error so the caller (and
+			// any batch flush awaiting this member) is not left hanging, then fail
+			// the connection so the panic is surfaced rather than silently
+			// swallowed.
 			if ir.isCall && ir.replied.done.CompareAndSwap(false, true) {
-				_ = c.sendResponse(ir, ir.id, nil, nil, Errorf(InternalError, "jsonrpc2: handler panicked: %v", r))
+				_ = c.sendResponse(ir, ir.id, bc, nil, Errorf(InternalError, "jsonrpc2: handler panicked: %v", r))
 			}
-			c.fail(fmt.Errorf("jsonrpc2: handler for %q panicked: %v", ir.reqV2.method, r))
+			c.fail(fmt.Errorf("jsonrpc2: handler for %q panicked: %v", ir.request.method, r))
 		}
 	}()
 
-	result, err := c.directHandler(ir, &ir.reqV2)
+	result, err := c.handler(ir, &ir.request)
 	if !ir.isCall {
 		// A notification has no response; a handler error is a connection-level
-		// failure, matching the closure path's contract.
+		// failure.
 		if err != nil {
 			c.fail(err)
 		}
 		return
 	}
 	if ir.replied.done.CompareAndSwap(false, true) {
-		_ = c.sendResponse(ir, ir.id, nil, result, err)
+		_ = c.sendResponse(ir, ir.id, bc, result, err)
 	}
+}
+
+// handleRequest dispatches a single (non-batch) incoming request inline on
+// the read goroutine. The handler runs to completion on this goroutine in the
+// common synchronous case, so it spawns no goroutine and handlers observe
+// requests in wire order.
+//
+// When the handler releases itself with [Async], the release effect spawns a
+// fresh read goroutine to take over the reader role and records the handoff;
+// handleRequest then reports it so the current read loop returns while this
+// goroutine finishes the handler concurrently. The successor reader owns loop
+// termination, so the reader role is always held by exactly one goroutine.
+func (c *conn) handleRequest(ctx context.Context, rv Request) (handedOff bool) {
+	ir, done := c.setupRequest(ctx, rv, nil)
+	if done {
+		return false
+	}
+
+	// The inline releaser carries the state for the Async handoff (ch left
+	// nil). It is a value field of ir, so initializing it in place allocates
+	// nothing.
+	ir.rel = releaser{active: true, conn: c, ctx: ctx, ir: ir}
+
+	c.runHandler(ir, nil)
+
+	// The pool put is the LAST touch on ir: it must come after the release-flag
+	// reads, because the instant ir is pooled another reader can recycle it. A
+	// detached (Async) request is never pooled -- its lifetime escaped the
+	// dispatch path and a detached handler may legally hold it until it returns
+	// on its own schedule.
+	handedOff = ir.rel.handedOff
+	if !ir.rel.detached {
+		putIncomingRequest(ir)
+	}
+	return handedOff
+}
+
+// handleBoxedRequest serves the rare boxed single-message paths: the
+// non-frame Stream.Read fallback and the synthetic empty-batch error member.
+func (c *conn) handleBoxedRequest(ctx context.Context, req RequestMessage) (handedOff bool) {
+	if inv, ok := req.(*invalidRequest); ok {
+		// A malformed request never reaches the handler; answer it directly
+		// with a null-id error response.
+		c.writeInvalid(ctx, nil, inv.err)
+		return false
+	}
+	return c.handleRequest(ctx, requestValue(req))
 }
 
 // handleBatchMember dispatches one batch member. Unlike the inline
 // single-message path, a batch member runs in its own goroutine gated by a
-// [releaser] channel so that an async member can overlap the remaining members
-// of the same batch: the dispatch loop blocks until the member either calls
-// [Async] (releasing it to run concurrently) or returns.
-func (c *conn) handleBatchMember(ctx context.Context, handler Handler, req Request, bc *batchCollector) {
-	ir, done := c.setupRequest(ctx, req, bc)
+// [releaser] channel so that an async member can overlap the remaining
+// members of the same batch: the dispatch loop blocks until the member either
+// calls [Async] (releasing it to run concurrently) or returns.
+func (c *conn) handleBatchMember(ctx context.Context, req RequestMessage, bc *batchCollector) {
+	if inv, ok := req.(*invalidRequest); ok {
+		// A malformed batch member never reaches the handler; answer it directly
+		// with a null-id error response so the valid members are still served.
+		c.writeInvalid(ctx, bc, inv.err)
+		return
+	}
+
+	ir, done := c.setupRequest(ctx, requestValue(req), bc)
 	if done {
 		return
 	}
 
 	ir.rel = releaser{active: true, ch: make(chan struct{}), ir: ir}
 
-	reply, replied := c.replier(ir, bc)
+	// The gate channel must be captured before the member goroutine starts: a
+	// fast synchronous member can close it AND recycle ir (zeroing ir.rel)
+	// before this goroutine would otherwise load the field.
+	ch := ir.rel.ch
+	go c.runBatchMember(ir, bc)
 
-	go c.runHandler(handler, ir, &ir.rel, reply, replied)
-
-	// Block until the member releases the dispatch loop: immediately for an async
-	// member (via Async), or when the handler returns for a synchronous one.
-	<-ir.rel.ch
+	// Block until the member releases the dispatch loop: immediately for an
+	// async member (via Async), or when the handler returns for a synchronous
+	// one.
+	<-ch
 }
 
-// repliedFlag reports whether a request's [Replier] has been invoked. It is
-// shared between the handler goroutine (which may reply from any goroutine once
-// the request is released with [Async]) and the dispatch goroutine's deferred
-// fallback, so it is backed by an atomic to make the read/write race-free.
+// runBatchMember runs one batch member's handler on its own goroutine and
+// recycles the request afterward. The release flags are written by the hard
+// release on this same goroutine (Async is called by the handler running
+// here), so the post-run read carries no race.
+func (c *conn) runBatchMember(ir *incomingRequest, bc *batchCollector) {
+	c.runHandler(ir, bc)
+	if !ir.rel.detached {
+		putIncomingRequest(ir)
+	}
+}
+
+// repliedFlag reports whether a request has been answered. It is shared
+// between the handler path (which answers from return values or the panic
+// fallback) and the complete path, so it is backed by an atomic to make the
+// first-answer race deterministic.
 type repliedFlag struct {
 	done atomic.Bool
-}
-
-// value reports whether the reply has been sent.
-func (f *repliedFlag) value() bool { return f.done.Load() }
-
-// notificationReplied is a shared flag that always reads "replied". A
-// notification expects no response, so the dispatch fallback must never fire for
-// it; returning this flag avoids allocating a per-notification flag.
-var notificationReplied = newRepliedFlag(true)
-
-// newRepliedFlag returns a [repliedFlag] preset to done.
-func newRepliedFlag(done bool) *repliedFlag {
-	f := &repliedFlag{}
-	f.done.Store(done)
-	return f
-}
-
-// replier builds the [Replier] for an incoming request together with a flag
-// reporting whether the reply has been sent. For a notification the replier is a
-// no-op and the flag always reads true (no response is expected). For a call the
-// replier writes the response, or, in a batch, collects the encoded response for
-// the array flush, and marks the flag the first time it is invoked.
-func (c *conn) replier(ir *incomingRequest, bc *batchCollector) (Replier, *repliedFlag) {
-	id, isCall := callID(ir.req)
-	if !isCall {
-		// Notifications carry no id and receive no response.
-		return func(context.Context, any, error) error { return nil }, notificationReplied
-	}
-
-	// flag is &ir.replied: the replied flag is a value field of the request, so it
-	// shares ir's single allocation rather than a separate &repliedFlag{}.
-	flag := &ir.replied
-	return func(ctx context.Context, result any, err error) error {
-		if !flag.done.CompareAndSwap(false, true) {
-			// A duplicate reply is a programming error in the handler; ignore it
-			// rather than writing a second, unmatched response.
-			return nil
-		}
-		return c.sendResponse(ctx, id, bc, result, err)
-	}, flag
 }
 
 // sendResponse marshals result (or err) into a response wire envelope and
@@ -321,14 +251,6 @@ func (c *conn) sendResponse(ctx context.Context, id ID, bc *batchCollector, resu
 		return nil
 	}
 	return c.writeResponse(ctx, resp.id, resp.result, resp.err)
-}
-
-// completeRequest answers req with an error without invoking the handler, used
-// to reject calls that arrive while the connection is shutting down.
-func (c *conn) completeRequest(ctx context.Context, ir *incomingRequest, bc *batchCollector, result any, err error) {
-	reply, _ := c.replier(ir, bc)
-	_ = reply(ctx, result, err)
-	c.afterHandle(ir)
 }
 
 // afterHandle releases the per-request resources and decrements the in-flight
@@ -368,13 +290,4 @@ func (c *conn) fail(err error) {
 			s.closer = nil
 		}
 	})
-}
-
-// callID reports the id of req and whether req is a call (and therefore expects
-// a response).
-func callID(req Request) (id ID, isCall bool) {
-	if c, ok := req.(*Call); ok {
-		return c.id, true
-	}
-	return ID{}, false
 }

--- a/dispatch_direct_test.go
+++ b/dispatch_direct_test.go
@@ -15,14 +15,14 @@ import (
 
 // newDirectPair builds a connected client/server pair over net.Pipe with
 // NDJSON framing, the server running h in direct-return mode.
-func newDirectPair(t *testing.T, h HandlerV2) (client, server Conn) {
+func newDirectPair(t *testing.T, h Handler) (client, server Conn) {
 	t.Helper()
 	ctx := t.Context()
 	ca, cb := net.Pipe()
 	client = NewConn(NewNDJSONStream(ca))
 	server = NewConn(NewNDJSONStream(cb))
 	client.Go(ctx, MethodNotFoundHandler)
-	server.GoDirect(ctx, h)
+	server.Go(ctx, h)
 	t.Cleanup(func() {
 		_ = client.Close()
 		<-client.Done()
@@ -32,10 +32,10 @@ func newDirectPair(t *testing.T, h HandlerV2) (client, server Conn) {
 	return client, server
 }
 
-// TestGoDirectRoundTrip exercises the direct-return dispatch surface end to
+// TestDirectRoundTrip exercises the direct-return dispatch surface end to
 // end: calls with and without params, the error return becoming a wire error,
 // and notifications reaching the handler.
-func TestGoDirectRoundTrip(t *testing.T) {
+func TestDirectRoundTrip(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
@@ -59,7 +59,7 @@ func TestGoDirectRoundTrip(t *testing.T) {
 		},
 	}
 
-	handler := func(ctx context.Context, req *RequestV2) (any, error) {
+	handler := func(ctx context.Context, req *Request) (any, error) {
 		if req.Method() == "fail" {
 			return nil, Errorf(InvalidParams, "rejected")
 		}
@@ -93,9 +93,9 @@ func TestGoDirectRoundTrip(t *testing.T) {
 	}
 }
 
-// TestGoDirectNotification proves notifications reach the direct handler and
+// TestDirectNotification proves notifications reach the direct handler and
 // produce no response.
-func TestGoDirectNotification(t *testing.T) {
+func TestDirectNotification(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
@@ -107,7 +107,7 @@ func TestGoDirectNotification(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			seen := make(chan string, 1)
-			client, _ := newDirectPair(t, func(ctx context.Context, req *RequestV2) (any, error) {
+			client, _ := newDirectPair(t, func(ctx context.Context, req *Request) (any, error) {
 				if !req.IsCall() {
 					seen <- req.Method()
 				}
@@ -123,10 +123,10 @@ func TestGoDirectNotification(t *testing.T) {
 	}
 }
 
-// TestGoDirectHandlerPanicAnswersCall proves the direct path's panic fallback:
+// TestDirectHandlerPanicAnswersCall proves the direct path's panic fallback:
 // the caller receives an InternalError response rather than hanging, and the
 // connection then fails (surfacing the panic) per the [Handler] contract.
-func TestGoDirectHandlerPanicAnswersCall(t *testing.T) {
+func TestDirectHandlerPanicAnswersCall(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
@@ -137,7 +137,7 @@ func TestGoDirectHandlerPanicAnswersCall(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			client, server := newDirectPair(t, func(ctx context.Context, req *RequestV2) (any, error) {
+			client, server := newDirectPair(t, func(ctx context.Context, req *Request) (any, error) {
 				panic("kaboom")
 			})
 			_, err := client.Call(t.Context(), tt.method, nil, nil)
@@ -156,11 +156,11 @@ func TestGoDirectHandlerPanicAnswersCall(t *testing.T) {
 	}
 }
 
-// TestGoDirectAsyncClonesRequest proves the single-escape-point contract: a
+// TestDirectAsyncClonesRequest proves the single-escape-point contract: a
 // handler that releases itself with [Async] keeps a valid request afterward
 // because the hard release clones the borrowed spans in place, even while the
 // successor reader is already overwriting the transport frame.
-func TestGoDirectAsyncClonesRequest(t *testing.T) {
+func TestDirectAsyncClonesRequest(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
@@ -181,7 +181,7 @@ func TestGoDirectAsyncClonesRequest(t *testing.T) {
 			release := make(chan struct{})
 			var once sync.Once
 
-			client, _ := newDirectPair(t, func(ctx context.Context, req *RequestV2) (any, error) {
+			client, _ := newDirectPair(t, func(ctx context.Context, req *Request) (any, error) {
 				if req.Method() == "later" {
 					return nil, nil
 				}
@@ -221,8 +221,8 @@ func TestGoDirectAsyncClonesRequest(t *testing.T) {
 }
 
 // TestPooledRequestFieldReset is the white-box mirror of putWaiter's
-// discipline: every field of a pooled incomingRequest must be zero after put,
-// so a recycled request cannot leak its previous life.
+// discipline: every field of a recycled incomingRequest must be zero after
+// the pool-put reset, so a recycled request cannot leak its previous life.
 func TestPooledRequestFieldReset(t *testing.T) {
 	t.Parallel()
 
@@ -237,23 +237,26 @@ func TestPooledRequestFieldReset(t *testing.T) {
 			ir.id = NewNumberID(7)
 			ir.isCall = true
 			ir.canceled = true
-			ir.reqV2 = RequestV2{id: NewNumberID(7), method: "m", params: RawMessage(`1`), isCall: true}
+			ir.request = Request{id: NewNumberID(7), method: "m", params: RawMessage(`1`), isCall: true}
 			ir.rel = releaser{active: true}
 			ir.replied.done.Store(true)
 
-			putIncomingRequest(ir)
+			// resetIncomingRequest is the same reset the pool put applies; calling
+			// it directly keeps ir out of the global pool, which a concurrently
+			// running test's dispatch could otherwise recycle mid-assertion.
+			resetIncomingRequest(ir)
 
-			if ir.req != nil || ir.parent != nil || ir.realCtx != nil || ir.realCancel != nil {
-				t.Errorf("context fields not reset: req=%v parent=%v realCtx=%v", ir.req, ir.parent, ir.realCtx)
+			if ir.parent != nil || ir.realCtx != nil || ir.realCancel != nil {
+				t.Errorf("context fields not reset: parent=%v parent2=%v realCtx=%v", ir.parent, ir.parent, ir.realCtx)
 			}
 			// Under the poison build the body carries sentinels instead of zeros;
 			// either way it must not carry the previous request's data.
-			if !strings.Contains(ir.reqV2.method, "POISON") {
-				if ir.reqV2.method != "" || ir.reqV2.params != nil || ir.reqV2.isCall || ir.reqV2.id != (ID{}) {
-					t.Errorf("reqV2 not reset: %+v", ir.reqV2)
+			if !strings.Contains(ir.request.method, "POISON") {
+				if ir.request.method != "" || ir.request.params != nil || ir.request.isCall || ir.request.id != (ID{}) {
+					t.Errorf("reqV2 not reset: %+v", ir.request)
 				}
 			}
-			if ir.rel.active || ir.rel.released || ir.rel.handedOff || ir.rel.ch != nil || ir.rel.ir != nil || ir.rel.conn != nil || ir.rel.handler != nil || ir.rel.ctx != nil {
+			if ir.rel.active || ir.rel.released || ir.rel.handedOff || ir.rel.ch != nil || ir.rel.ir != nil || ir.rel.conn != nil || ir.rel.ctx != nil {
 				t.Errorf("releaser not reset: active=%v released=%v handedOff=%v", ir.rel.active, ir.rel.released, ir.rel.handedOff)
 			}
 			if ir.id != (ID{}) || ir.isCall || ir.canceled || ir.replied.done.Load() {
@@ -263,9 +266,9 @@ func TestPooledRequestFieldReset(t *testing.T) {
 	}
 }
 
-// TestGoDirectBatch proves batch frames still work in direct mode through the
+// TestDirectBatch proves batch frames still work in direct mode through the
 // compat adapter: every call member is answered in one response array.
-func TestGoDirectBatch(t *testing.T) {
+func TestDirectBatch(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
@@ -283,7 +286,7 @@ func TestGoDirectBatch(t *testing.T) {
 			ctx := t.Context()
 			a, b := NewChannelStreamPair(4)
 			server := NewConn(b)
-			server.GoDirect(ctx, func(ctx context.Context, req *RequestV2) (any, error) {
+			server.Go(ctx, func(ctx context.Context, req *Request) (any, error) {
 				return req.Method(), nil
 			})
 			t.Cleanup(func() {

--- a/dispatch_direct_test.go
+++ b/dispatch_direct_test.go
@@ -5,6 +5,7 @@ package jsonrpc2
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"strings"
 	"sync"
@@ -215,6 +216,74 @@ func TestDirectAsyncClonesRequest(t *testing.T) {
 			got := <-gotMethod
 			if got[0] != tt.first || got[1] != tt.params {
 				t.Errorf("async handler observed (method, params) = (%q, %q), want (%q, %q); the hard release must clone the borrowed spans", got[0], got[1], tt.first, tt.params)
+			}
+		})
+	}
+}
+
+// TestDirectBatchAsyncMemberClonesRequest pins the batch arm of the
+// single-escape-point contract: a batch member that releases itself with
+// [Async] keeps valid method and params after later frames have reused the
+// transport buffer, because the hard release cloned the borrowed spans.
+func TestDirectBatchAsyncMemberClonesRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		frame  string
+		others int
+	}{
+		"success: async batch member survives later frames": {
+			frame:  `[{"jsonrpc":"2.0","id":1,"method":"pin","params":{"keep":"me"}},{"jsonrpc":"2.0","id":2,"method":"quick"}]`,
+			others: 8,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			a, b := NewChannelStreamPair(4)
+			observed := make(chan [2]string, 1)
+			release := make(chan struct{})
+
+			server := NewConn(b)
+			server.Go(ctx, func(ctx context.Context, req *Request) (any, error) {
+				if req.Method() != "pin" {
+					return req.Method(), nil
+				}
+				Async(ctx)
+				<-release
+				observed <- [2]string{req.Method(), string(req.Params())}
+				return "pinned", nil
+			})
+			t.Cleanup(func() {
+				_ = server.Close()
+				<-server.Done()
+			})
+
+			fw := a.(frameStream)
+			if _, err := fw.WriteFrame(ctx, []byte(tt.frame)); err != nil {
+				t.Fatalf("WriteFrame: %v", err)
+			}
+			// Drive later single requests through the same frame pool while the
+			// async member is parked.
+			for i := range tt.others {
+				wire := fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"later","params":{"overwrite":"frame %d"}}`, 100+i, i)
+				if _, err := fw.WriteFrame(ctx, []byte(wire)); err != nil {
+					t.Fatalf("later WriteFrame: %v", err)
+				}
+				if _, _, err := fw.ReadFrame(ctx); err != nil {
+					t.Fatalf("later ReadFrame: %v", err)
+				}
+			}
+			close(release)
+
+			got := <-observed
+			if got[0] != "pin" || got[1] != `{"keep":"me"}` {
+				t.Errorf("async batch member observed (method, params) = (%q, %q), want (pin, {\"keep\":\"me\"}); the hard release must clone the borrowed spans", got[0], got[1])
+			}
+			// Drain the batch response array.
+			if _, _, err := fw.ReadFrame(ctx); err != nil {
+				t.Fatalf("batch response ReadFrame: %v", err)
 			}
 		})
 	}

--- a/dispatch_v2_test.go
+++ b/dispatch_v2_test.go
@@ -1,0 +1,307 @@
+// Copyright 2026 The Go Language Server Authors. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package jsonrpc2
+
+import (
+	"context"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+
+	gocmp "github.com/google/go-cmp/cmp"
+)
+
+// newDirectPair builds a connected client/server pair over net.Pipe with
+// NDJSON framing, the server running h in direct-return mode.
+func newDirectPair(t *testing.T, h HandlerV2) (client, server Conn) {
+	t.Helper()
+	ctx := t.Context()
+	ca, cb := net.Pipe()
+	client = NewConn(NewNDJSONStream(ca))
+	server = NewConn(NewNDJSONStream(cb))
+	client.Go(ctx, MethodNotFoundHandler)
+	server.GoDirect(ctx, h)
+	t.Cleanup(func() {
+		_ = client.Close()
+		<-client.Done()
+		_ = server.Close()
+		<-server.Done()
+	})
+	return client, server
+}
+
+// TestGoDirectRoundTrip exercises the direct-return dispatch surface end to
+// end: calls with and without params, the error return becoming a wire error,
+// and notifications reaching the handler.
+func TestGoDirectRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		method     string
+		params     any
+		wantResult string
+		wantErr    bool
+	}{
+		"success: void call round trip": {
+			method:     "void",
+			wantResult: `"void:"`,
+		},
+		"success: params echo through the borrowed span": {
+			method:     "echo",
+			params:     RawMessage(`{"k":"v"}`),
+			wantResult: `"echo:{\"k\":\"v\"}"`,
+		},
+		"error: handler error becomes the wire error response": {
+			method:  "fail",
+			wantErr: true,
+		},
+	}
+
+	handler := func(ctx context.Context, req *RequestV2) (any, error) {
+		if req.Method() == "fail" {
+			return nil, Errorf(InvalidParams, "rejected")
+		}
+		return req.Method() + ":" + string(req.Params()), nil
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			client, _ := newDirectPair(t, handler)
+
+			var got RawMessage
+			_, err := client.Call(t.Context(), tt.method, tt.params, &got)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Call(%q) succeeded, want wire error", tt.method)
+				}
+				var werr *Error
+				if !asError(err, &werr) || werr.Code != InvalidParams {
+					t.Fatalf("Call(%q) error = %v, want *Error with InvalidParams", tt.method, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Call(%q): %v", tt.method, err)
+			}
+			if diff := gocmp.Diff(tt.wantResult, string(got)); diff != "" {
+				t.Errorf("result mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestGoDirectNotification proves notifications reach the direct handler and
+// produce no response.
+func TestGoDirectNotification(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		method string
+	}{
+		"success: notification dispatched without reply": {method: "note"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			seen := make(chan string, 1)
+			client, _ := newDirectPair(t, func(ctx context.Context, req *RequestV2) (any, error) {
+				if !req.IsCall() {
+					seen <- req.Method()
+				}
+				return nil, nil
+			})
+			if err := client.Notify(t.Context(), tt.method, nil); err != nil {
+				t.Fatalf("Notify: %v", err)
+			}
+			if got := <-seen; got != tt.method {
+				t.Errorf("handler saw method %q, want %q", got, tt.method)
+			}
+		})
+	}
+}
+
+// TestGoDirectHandlerPanicAnswersCall proves the direct path's panic fallback:
+// the caller receives an InternalError response rather than hanging, and the
+// connection then fails (surfacing the panic) per the [Handler] contract.
+func TestGoDirectHandlerPanicAnswersCall(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		method string
+	}{
+		"error: panicking handler answers the call with InternalError": {method: "boom"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			client, server := newDirectPair(t, func(ctx context.Context, req *RequestV2) (any, error) {
+				panic("kaboom")
+			})
+			_, err := client.Call(t.Context(), tt.method, nil, nil)
+			if err == nil {
+				t.Fatalf("Call(%q) succeeded, want InternalError from panicking handler", tt.method)
+			}
+			var werr *Error
+			if !asError(err, &werr) || werr.Code != InternalError {
+				t.Fatalf("Call(%q) error = %v, want *Error with InternalError", tt.method, err)
+			}
+			<-server.Done()
+			if server.Err() == nil {
+				t.Errorf("server.Err() = nil, want the surfaced handler panic")
+			}
+		})
+	}
+}
+
+// TestGoDirectAsyncClonesRequest proves the single-escape-point contract: a
+// handler that releases itself with [Async] keeps a valid request afterward
+// because the hard release clones the borrowed spans in place, even while the
+// successor reader is already overwriting the transport frame.
+func TestGoDirectAsyncClonesRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		first  string
+		params string
+		others int
+	}{
+		"success: async handler reads cloned method and params after later requests": {
+			first:  "async-method",
+			params: `{"keep":"me"}`,
+			others: 8,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			gotMethod := make(chan [2]string, 1)
+			release := make(chan struct{})
+			var once sync.Once
+
+			client, _ := newDirectPair(t, func(ctx context.Context, req *RequestV2) (any, error) {
+				if req.Method() == "later" {
+					return nil, nil
+				}
+				once.Do(func() {
+					Async(ctx)
+					// The successor reader is live now; wait until the test has
+					// driven several later requests through the same frame buffer.
+					<-release
+					gotMethod <- [2]string{req.Method(), string(req.Params())}
+				})
+				return nil, nil
+			})
+
+			ctx := t.Context()
+			done := make(chan error, 1)
+			go func() {
+				_, err := client.Call(ctx, tt.first, RawMessage(tt.params), nil)
+				done <- err
+			}()
+
+			for range tt.others {
+				if _, err := client.Call(ctx, "later", RawMessage(`{"overwrite":"frame"}`), nil); err != nil {
+					t.Fatalf("later Call: %v", err)
+				}
+			}
+			close(release)
+			if err := <-done; err != nil {
+				t.Fatalf("async Call: %v", err)
+			}
+
+			got := <-gotMethod
+			if got[0] != tt.first || got[1] != tt.params {
+				t.Errorf("async handler observed (method, params) = (%q, %q), want (%q, %q); the hard release must clone the borrowed spans", got[0], got[1], tt.first, tt.params)
+			}
+		})
+	}
+}
+
+// TestPooledRequestFieldReset is the white-box mirror of putWaiter's
+// discipline: every field of a pooled incomingRequest must be zero after put,
+// so a recycled request cannot leak its previous life.
+func TestPooledRequestFieldReset(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct{}{
+		"success: every field zeroed on put": {},
+	}
+	for name := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ir := getIncomingRequest()
+			ir.parent = context.Background()
+			ir.id = NewNumberID(7)
+			ir.isCall = true
+			ir.canceled = true
+			ir.reqV2 = RequestV2{id: NewNumberID(7), method: "m", params: RawMessage(`1`), isCall: true}
+			ir.rel = releaser{active: true}
+			ir.replied.done.Store(true)
+
+			putIncomingRequest(ir)
+
+			if ir.req != nil || ir.parent != nil || ir.realCtx != nil || ir.realCancel != nil {
+				t.Errorf("context fields not reset: req=%v parent=%v realCtx=%v", ir.req, ir.parent, ir.realCtx)
+			}
+			// Under the poison build the body carries sentinels instead of zeros;
+			// either way it must not carry the previous request's data.
+			if !strings.Contains(ir.reqV2.method, "POISON") {
+				if ir.reqV2.method != "" || ir.reqV2.params != nil || ir.reqV2.isCall || ir.reqV2.id != (ID{}) {
+					t.Errorf("reqV2 not reset: %+v", ir.reqV2)
+				}
+			}
+			if ir.rel.active || ir.rel.released || ir.rel.handedOff || ir.rel.ch != nil || ir.rel.ir != nil || ir.rel.conn != nil || ir.rel.handler != nil || ir.rel.ctx != nil {
+				t.Errorf("releaser not reset: active=%v released=%v handedOff=%v", ir.rel.active, ir.rel.released, ir.rel.handedOff)
+			}
+			if ir.id != (ID{}) || ir.isCall || ir.canceled || ir.replied.done.Load() {
+				t.Errorf("scalar fields not reset: id=%v isCall=%v canceled=%v replied=%v", ir.id, ir.isCall, ir.canceled, ir.replied.done.Load())
+			}
+		})
+	}
+}
+
+// TestGoDirectBatch proves batch frames still work in direct mode through the
+// compat adapter: every call member is answered in one response array.
+func TestGoDirectBatch(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		frame      string
+		wantBodies int
+	}{
+		"success: two calls and one notification answered as a two-element array": {
+			frame:      `[{"jsonrpc":"2.0","id":1,"method":"a"},{"jsonrpc":"2.0","id":2,"method":"b"},{"jsonrpc":"2.0","method":"note"}]`,
+			wantBodies: 2,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			a, b := NewChannelStreamPair(4)
+			server := NewConn(b)
+			server.GoDirect(ctx, func(ctx context.Context, req *RequestV2) (any, error) {
+				return req.Method(), nil
+			})
+			t.Cleanup(func() {
+				_ = server.Close()
+				<-server.Done()
+			})
+
+			fw := a.(frameStream)
+			if _, err := fw.WriteFrame(ctx, []byte(tt.frame)); err != nil {
+				t.Fatalf("WriteFrame: %v", err)
+			}
+			resp, _, err := fw.ReadFrame(ctx)
+			if err != nil {
+				t.Fatalf("ReadFrame: %v", err)
+			}
+			if got := strings.Count(string(resp), `"result"`); got != tt.wantBodies {
+				t.Errorf("response array %s carries %d results, want %d", resp, got, tt.wantBodies)
+			}
+		})
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -9,15 +9,21 @@
 // machine. The wire core encodes message envelopes by appending directly into a
 // byte buffer ([EncodeMessage], [AppendMessage], [AppendCall],
 // [AppendNotification], [AppendResponse], [AppendBatch]) and decodes them with
-// a single-pass span scanner ([DecodeMessage], [ParseRequests]), so the hot path
-// performs no reflection and copies each payload at most once.
+// a single-pass span scanner ([DecodeMessage], [ParseRequests]), so the hot
+// path performs no reflection and no payload copies: a served request borrows
+// its method and params straight from the transport frame, the request
+// bookkeeping is pooled, and dispatch is direct-return, which is what lets a
+// void round trip measure zero allocations.
 //
-// [EncodeMessage], [DecodeMessage], and [ParseRequests] return owned values.
-// For callback-scoped experimental parser fast paths, [ScanMessageView],
-// [ScanFrameView], and [AppendRequestViews] expose borrowed views over
-// caller-owned frame bytes; those views are valid only while the source frame
-// remains valid and unmodified. They are not the default owned decode path unless
-// a caller's benchmark proves that the borrowed lifetime trade-off wins.
+// The borrow has one rule: a [Handler]'s request, its Method, and its Params
+// are valid only until the handler returns. [Request.Clone] takes an owned
+// copy, [Async] clones automatically when a handler detaches, and
+// [DetachContext] keeps a context alive past the handler. The same contract
+// applies to requests decoded by [DecodeMessage] and [ParseRequests], whose
+// results borrow their input; responses and error members are owned. For
+// callback-scoped parser fast paths, [ScanMessageView], [ScanFrameView], and
+// [AppendRequestViews] expose the same kind of borrowed views over
+// caller-owned frame bytes.
 //
 // Runtime modes are explicit: [Conn]/[Peer] is bidirectional, [SingleClient]
 // serializes calls with a caller-owned read loop, [PipelineClient] keeps
@@ -26,8 +32,9 @@
 // [NewChannelStreamPair] supplies an in-memory encoded-frame transport for
 // same-process peers that still want full JSON-RPC wire encoding and scanning.
 //
-// The message types are a closed set of [*Call], [*Notification], and
-// [*Response], all of which implement the [Message] interface.
+// The wire-model message types are a closed set of [*Call], [*Notification],
+// and [*Response], all of which implement the [Message] interface; handlers
+// receive the concrete [Request] instead.
 //
 // # Framing
 //

--- a/examples/batch/main.go
+++ b/examples/batch/main.go
@@ -103,33 +103,33 @@ func run(ctx context.Context, out io.Writer) error {
 }
 
 func batchHandler(logged chan<- string) jsonrpc2.Handler {
-	return func(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+	return func(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 		switch req.Method() {
 		case "math/sum":
 			var params sumParams
 			if err := jsonrpc2.DefaultCodec.Unmarshal(req.Params(), &params); err != nil {
-				return reply(ctx, nil, err)
+				return nil, err
 			}
 			sum := 0
 			for _, value := range params.Values {
 				sum += value
 			}
-			return reply(ctx, sumResult{Sum: sum}, nil)
+			return sumResult{Sum: sum}, nil
 
 		case "telemetry/log":
 			var params logParams
 			if err := jsonrpc2.DefaultCodec.Unmarshal(req.Params(), &params); err != nil {
-				return err
+				return nil, err
 			}
 			select {
 			case logged <- params.Message:
 			case <-ctx.Done():
-				return ctx.Err()
+				return nil, ctx.Err()
 			}
-			return reply(ctx, nil, nil)
+			return nil, nil
 
 		default:
-			return jsonrpc2.MethodNotFoundHandler(ctx, reply, req)
+			return jsonrpc2.MethodNotFoundHandler(ctx, req)
 		}
 	}
 }

--- a/examples/peer/main.go
+++ b/examples/peer/main.go
@@ -80,31 +80,31 @@ func run(ctx context.Context, out io.Writer) error {
 }
 
 func peerHandler(saved chan<- string) jsonrpc2.Handler {
-	return func(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+	return func(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 		switch req.Method() {
 		case "textDocument/hover":
 			var params hoverParams
 			if err := jsonrpc2.DefaultCodec.Unmarshal(req.Params(), &params); err != nil {
-				return reply(ctx, nil, err)
+				return nil, err
 			}
-			return reply(ctx, hoverResult{
+			return hoverResult{
 				Contents: fmt.Sprintf("hover for %s:%d", params.URI, params.Line),
-			}, nil)
+			}, nil
 
 		case "textDocument/didSave":
 			var params saveParams
 			if err := jsonrpc2.DefaultCodec.Unmarshal(req.Params(), &params); err != nil {
-				return err
+				return nil, err
 			}
 			select {
 			case saved <- params.URI:
 			case <-ctx.Done():
-				return ctx.Err()
+				return nil, ctx.Err()
 			}
-			return reply(ctx, nil, nil)
+			return nil, nil
 
 		default:
-			return jsonrpc2.MethodNotFoundHandler(ctx, reply, req)
+			return jsonrpc2.MethodNotFoundHandler(ctx, req)
 		}
 	}
 }

--- a/examples/serve/main.go
+++ b/examples/serve/main.go
@@ -95,18 +95,18 @@ func run(ctx context.Context, out io.Writer) error {
 	return nil
 }
 
-func symbolHandler(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+func symbolHandler(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	if req.Method() != "workspace/symbol" {
-		return jsonrpc2.MethodNotFoundHandler(ctx, reply, req)
+		return jsonrpc2.MethodNotFoundHandler(ctx, req)
 	}
 
 	var params symbolParams
 	if err := jsonrpc2.DefaultCodec.Unmarshal(req.Params(), &params); err != nil {
-		return reply(ctx, nil, err)
+		return nil, err
 	}
 
-	return reply(ctx, symbolResult{
+	return symbolResult{
 		Name: params.Query,
 		Kind: "interface",
-	}, nil)
+	}, nil
 }

--- a/framer.go
+++ b/framer.go
@@ -28,6 +28,10 @@ type Stream interface {
 	// Read decodes the next message from the stream. It returns [io.EOF] when
 	// the peer closes the connection at a clean frame boundary, and
 	// [io.ErrUnexpectedEOF] when the connection ends in the middle of a frame.
+	//
+	// A decoded request's method and params borrow the stream's read buffer
+	// and are valid only until the next Read; copy what you retain. Responses
+	// own their bytes.
 	Read(ctx context.Context) (Message, int64, error)
 
 	// Write frames msg and writes it to the stream as a single contiguous write.
@@ -115,9 +119,9 @@ type ndjsonStream struct {
 }
 
 // Read implements [Stream]. It parses one LSP header block, reads the declared
-// body into a reused buffer, and decodes the message. The decoder copies every
-// span it needs into the returned message, so reusing the body buffer across
-// reads is safe.
+// body into a reused buffer, and decodes the message. A decoded request's
+// method and params borrow that buffer and are valid only until the next
+// read; copy what you retain.
 func (s *headerStream) Read(ctx context.Context) (Message, int64, error) {
 	body, n, err := s.ReadFrame(ctx)
 	if err != nil {
@@ -290,7 +294,9 @@ func (s *headerStream) WriteFrame(ctx context.Context, data []byte) (int64, erro
 func (s *headerStream) Close() error { return s.conn.Close() }
 
 // Read implements [Stream]. It reads up to and including the next '\n', decodes
-// the JSON value that precedes it, and returns the decoded message.
+// the JSON value that precedes it, and returns the decoded message. A decoded
+// request's method and params borrow the read buffer and are valid only until
+// the next read; copy what you retain.
 func (s *ndjsonStream) Read(ctx context.Context) (Message, int64, error) {
 	body, n, err := s.ReadFrame(ctx)
 	if err != nil {

--- a/handler.go
+++ b/handler.go
@@ -9,50 +9,19 @@ import (
 	"sync"
 )
 
-// Handler is invoked to handle an incoming [Request].
-//
-// The handler must call reply exactly once for a [*Call] (a request that
-// carries an id) to send the response; for a [*Notification] the reply is a
-// no-op and may be omitted. The error a handler returns is a connection-level
-// error: returning a non-nil error fails the connection. To answer a call with
-// a JSON-RPC error, pass that error to reply rather than returning it.
-//
-// Reentrancy and the deadlock-avoidance contract: in the synchronous case a
-// Handler runs inline on the connection's read loop, which is blocked until the
-// handler returns or releases itself. Because a [Conn] is symmetric, a handler
-// may call back into the same connection while serving a request (the pattern
-// LSP relies on), but it must observe one rule. To make a server-initiated
-// *call* back to the peer with [Conn.Call] and await its response from within a
-// handler, the handler MUST first release the read loop with [Async] (or be
-// wrapped with [AsyncHandler]); otherwise it deadlocks, because the response to
-// that callback must be read by the very read loop that is blocked running the
-// handler. A server-initiated *notification* with [Conn.Notify] does not require
-// [Async]: Notify only writes and never waits for a response, so the blocked
-// read loop never has to deliver one.
-//
-// The connection enforces a deterministic outcome for a misbehaving handler so a
-// stuck reply can never hang a caller or a batch array flush:
-//   - If a handler returns for a [*Call] without having called reply, the
-//     connection answers that call with an [InternalError] response.
-//   - If a handler panics, the connection answers an unanswered call with an
-//     [InternalError] response, then fails the connection so the panic is
-//     surfaced through [Conn.Err] rather than silently swallowed.
-type Handler func(ctx context.Context, reply Replier, req Request) error
-
-// HandlerV2 is the direct-return handler shape: the returned result (or error)
-// becomes the call's response, so dispatch needs no per-request reply closure.
-// The request is a concrete value embedded in the connection's per-request
-// bookkeeping; its method and params are borrowed and valid until the handler
-// returns. For a notification the result is discarded and a non-nil error
-// fails the connection, matching the [Handler] contract for handler-returned
-// errors.
+// Handler is invoked to handle an incoming [Request]. It is the direct-return
+// handler shape: the returned result (or error) becomes the call's response,
+// so dispatch needs no per-request reply machinery. To answer a call with a
+// JSON-RPC error, return that error (an [*Error] is sent verbatim; any other
+// error is wrapped). For a notification the result is discarded and a non-nil
+// error fails the connection.
 //
 // Lifetime contract: req, its Method, and its Params are valid only until the
-// handler returns; the struct is recycled afterward. The three legal retention
-// patterns are:
+// handler returns; the request struct is pooled and recycled afterward. The
+// three legal retention patterns are:
 //
 //  1. Copy what you need before returning (unmarshal params, copy the method).
-//  2. Take [RequestV2.Clone] and retain the owned clone.
+//  2. Take [Request.Clone] and retain the owned clone.
 //  3. Release with [Async], which clones the request in place automatically;
 //     the request then remains valid until the (now concurrent) handler
 //     returns.
@@ -60,7 +29,25 @@ type Handler func(ctx context.Context, reply Replier, req Request) error
 // The per-request ctx likewise dies with the handler; use [DetachContext] for
 // work that outlives it. Builds tagged jsonrpc2poison scribble recycled
 // requests so violations fail loudly in tests.
-type HandlerV2 func(ctx context.Context, req *RequestV2) (result any, err error)
+//
+// Reentrancy and the deadlock-avoidance contract: in the synchronous case a
+// Handler runs inline on the connection's read loop, which is blocked until
+// the handler returns or releases itself. Because a [Conn] is symmetric, a
+// handler may call back into the same connection while serving a request (the
+// pattern LSP relies on), but it must observe one rule. To make a
+// server-initiated *call* back to the peer with [Conn.Call] and await its
+// response from within a handler, the handler MUST first release the read
+// loop with [Async] (or be wrapped with [AsyncHandler]); otherwise it
+// deadlocks, because the response to that callback must be read by the very
+// read loop that is blocked running the handler. A server-initiated
+// *notification* with [Conn.Notify] does not require [Async]: Notify only
+// writes and never waits for a response.
+//
+// The connection enforces a deterministic outcome for a misbehaving handler:
+// if a handler panics, the connection answers an unanswered call with an
+// [InternalError] response, then fails the connection so the panic is
+// surfaced through [Conn.Err] rather than silently swallowed.
+type Handler func(ctx context.Context, req *Request) (result any, err error)
 
 // DetachContext returns a context that is safe to retain after the handler
 // returns. The per-request context handed to a handler is pooled and recycled
@@ -74,91 +61,65 @@ func DetachContext(ctx context.Context) context.Context {
 	return ctx
 }
 
-// Replier sends the reply to a [Request]. It is passed to a [Handler] and must
-// be called exactly once for a [*Call].
-//
-// When err is non-nil the result is ignored and an error response is written;
-// otherwise result is marshaled with the connection's [Codec] and written as a
-// success response. Replying to a [*Notification] writes nothing and returns
-// nil.
-type Replier func(ctx context.Context, result any, err error) error
-
 // Preempter is an optional hook consulted for every incoming [Request] before
-// it is queued for the [Handler]. It runs inline on the read loop, so it must
-// not block; it is intended for fast, ordered handling such as "$/cancelRequest"
-// notifications that must be observed ahead of the request they cancel.
+// it is dispatched to the [Handler]. It runs inline on the read loop, so it
+// must not block; it is intended for fast, ordered handling such as
+// "$/cancelRequest" notifications that must be observed ahead of the request
+// they cancel. The request follows the same borrowed lifetime as a Handler's:
+// valid only until Preempt returns.
 type Preempter interface {
-	// Preempt is called for each incoming request before it is queued. Returning
-	// [ErrNotHandled] (or a nil handled value) defers the request to the
-	// [Handler]; returning any other result handles the request inline and it is
-	// not passed to the Handler.
-	Preempt(ctx context.Context, req Request) (handled any, err error)
+	// Preempt is called for each incoming request before it is dispatched.
+	// Returning [ErrNotHandled] (or a nil handled value) defers the request to
+	// the [Handler]; returning any other result handles the request inline and
+	// it is not passed to the Handler.
+	Preempt(ctx context.Context, req *Request) (handled any, err error)
 }
 
 // ErrNotHandled is returned by a [Preempter] (or a [Handler]) to indicate that
 // the request was not handled and should fall through to the next stage.
 const ErrNotHandled = constError("jsonrpc2: request not handled")
 
-// MethodNotFoundHandler is a [Handler] that replies to every call with the
+// MethodNotFoundHandler is a [Handler] that answers every call with the
 // standard "method not found" error and drops notifications. It is intended to
 // be the final handler in a chain.
-func MethodNotFoundHandler(ctx context.Context, reply Replier, req Request) error {
-	return reply(ctx, nil, fmt.Errorf("%q: %w", req.Method(), ErrMethodNotFound))
-}
-
-// ReplyHandler wraps handler so that it panics if the wrapped handler does not
-// call its reply exactly once for each request it is passed. It is a
-// development aid that surfaces a missing or duplicated reply as an immediate
-// panic rather than a silently dropped or doubled response.
-func ReplyHandler(handler Handler) Handler {
-	return func(ctx context.Context, reply Replier, req Request) error {
-		called := false
-		err := handler(ctx, func(ctx context.Context, result any, err error) error {
-			if called {
-				panic(fmt.Errorf("jsonrpc2: request %q replied to more than once", req.Method()))
-			}
-			called = true
-			return reply(ctx, result, err)
-		}, req)
-		if !called {
-			panic(fmt.Errorf("jsonrpc2: request %q was never replied to", req.Method()))
-		}
-		return err
+func MethodNotFoundHandler(ctx context.Context, req *Request) (any, error) {
+	if !req.IsCall() {
+		return nil, nil
 	}
+	return nil, fmt.Errorf("%q: %w", req.Method(), ErrMethodNotFound)
 }
 
-// CancelHandler wraps handler to support cancellation by request id. It returns
-// the wrapped handler and a canceller that, when called with the id of an
-// in-flight [*Call], cancels the context passed to that call's handler.
+// CancelHandler wraps handler to support cancellation by request id. It
+// returns the wrapped handler and a canceller that, when called with the id of
+// an in-flight call, cancels the context passed to that call's handler.
 //
-// The canceller is safe for concurrent use and is a no-op for an id that is not
-// currently being handled.
+// The canceller is safe for concurrent use and is a no-op for an id that is
+// not currently being handled.
 func CancelHandler(handler Handler) (h Handler, canceller func(id ID)) {
 	var mu sync.Mutex
 	handling := make(map[ID]context.CancelFunc)
 
-	h = func(ctx context.Context, reply Replier, req Request) error {
-		call, ok := req.(*Call)
-		if !ok {
-			return handler(ctx, reply, req)
+	h = func(ctx context.Context, req *Request) (any, error) {
+		if !req.IsCall() {
+			return handler(ctx, req)
 		}
 
+		id := req.ID()
 		cancelCtx, cancel := context.WithCancel(ctx)
-		ctx = cancelCtx
 
 		mu.Lock()
-		handling[call.ID()] = cancel
+		handling[id] = cancel
 		mu.Unlock()
-
-		innerReply := reply
-		reply = func(ctx context.Context, result any, err error) error {
+		// The deregistration runs inside the wrapped handler, strictly before
+		// dispatch recycles the request, so the captured id stays valid.
+		defer func() {
 			mu.Lock()
-			delete(handling, call.ID())
+			delete(handling, id)
 			mu.Unlock()
 			cancel()
-			return innerReply(ctx, result, err)
-		}
-		return handler(ctx, reply, req)
+		}()
+
+		return handler(cancelCtx, req)
 	}
 
 	canceller = func(id ID) {
@@ -174,24 +135,26 @@ func CancelHandler(handler Handler) (h Handler, canceller func(id ID)) {
 }
 
 // AsyncHandler wraps handler so that every request is released for concurrent
-// handling as soon as it is received: the wrapped handler runs the inner
-// handler in its own goroutine and returns immediately, letting the connection
-// read the next message without waiting for the current request to complete.
+// handling as soon as it is received: the read loop hands its role to a
+// successor immediately and the wrapped handler continues concurrently.
 //
-// Requests are still started in wire order, but they run concurrently and carry
-// no mutual ordering guarantee once released. This unblocks the read loop at the
-// cost of unbounded handler goroutines.
+// Requests are still started in wire order, but they run concurrently and
+// carry no mutual ordering guarantee once released. The release clones the
+// request's borrowed spans, so the wrapped handler keeps a valid request for
+// as long as it runs.
 func AsyncHandler(handler Handler) Handler {
-	return func(ctx context.Context, reply Replier, req Request) error {
+	return func(ctx context.Context, req *Request) (any, error) {
 		Async(ctx)
-		return handler(ctx, reply, req)
+		return handler(ctx, req)
 	}
 }
 
 // Async signals that the current request may be handled concurrently with
 // requests that arrive after it. When ctx is a request context served by a
 // connection, the read loop is released to process the next message
-// immediately; the remainder of the handler then runs concurrently.
+// immediately; the remainder of the handler then runs concurrently. The
+// request's borrowed method and params are cloned in place by the release, so
+// they remain valid until the handler returns.
 //
 // Async must be called at most once per request context. Calling it on a
 // context that does not carry a release token (for example a non-request
@@ -213,7 +176,7 @@ type asyncKey struct{}
 // requests.
 //
 // The effect is selected by the populated fields rather than a per-request
-// closure, so dispatch allocates only the releaser itself:
+// closure, so dispatch allocates nothing for it:
 //
 //   - Batch member (ch != nil): either kind of release closes ch, unblocking
 //     the dispatch loop that spawned the member's goroutine.
@@ -222,9 +185,9 @@ type asyncKey struct{}
 //     handoff; a soft release is a no-op, since the read loop simply continues
 //     once the inline handler returns.
 //
-// A release effect must be safe to run on whichever goroutine first releases the
-// request; the inline handoff only ever runs on the read goroutine, since the
-// inline handler runs there.
+// A release effect must be safe to run on whichever goroutine first releases
+// the request; the inline handoff only ever runs on the read goroutine, since
+// the inline handler runs there.
 type releaser struct {
 	ctx context.Context
 
@@ -237,20 +200,26 @@ type releaser struct {
 	// before the read loop can advance to the next frame.
 	ir *incomingRequest
 
-	// The remaining fields drive the inline single-message handoff (ch == nil).
+	// conn drives the inline single-message handoff (ch == nil); the successor
+	// reader dispatches through conn.handler.
 	conn     *conn
-	handler  Handler
 	mu       sync.Mutex
 	released bool
 
 	// active marks the releaser as set up for an in-flight request. It is needed
-	// because the releaser is now a value field of incomingRequest rather than a
-	// separately-allocated pointer, so the zero value must be distinguishable from
-	// a releaser that dispatch has initialized; only an active releaser is handed
-	// out for the asyncKey{} context value.
+	// because the releaser is a value field of incomingRequest, so the zero
+	// value must be distinguishable from a releaser that dispatch has
+	// initialized; only an active releaser is handed out for the asyncKey{}
+	// context value.
 	active bool
 
-	handedOff bool // set by a hard release so the inline reader loop returns
+	// detached is set by a hard release on the releasing goroutine. The
+	// dispatch path reads it after the handler returns (same goroutine) to
+	// decide whether the request may be pooled: a detached request's lifetime
+	// escaped the dispatch path and is left to the garbage collector.
+	detached bool
+
+	handedOff bool // set by an inline hard release so the reader loop returns
 }
 
 // release runs the release effect exactly once. A hard release (soft=false)
@@ -269,13 +238,17 @@ func (r *releaser) release(soft bool) {
 	r.released = true
 	r.mu.Unlock()
 
-	if !soft && r.ir != nil {
-		// The handler is detaching from the read loop, so the borrowed method and
-		// params spans must stop aliasing the transport frame before the loop can
-		// read (and thereby invalidate) the next frame. Cloning here -- before the
-		// successor reader starts or the batch dispatch loop resumes -- is what
-		// makes the hard release the single legal escape point for a request.
-		r.ir.cloneRequestOwned()
+	if !soft {
+		r.detached = true
+		if r.ir != nil {
+			// The handler is detaching from the read loop, so the borrowed method
+			// and params spans must stop aliasing the transport frame before the
+			// loop can read (and thereby invalidate) the next frame. Cloning here --
+			// before the successor reader starts or the batch dispatch loop
+			// resumes -- is what makes the hard release the single legal escape
+			// point for a request.
+			r.ir.cloneRequestOwned()
+		}
 	}
 
 	switch {
@@ -287,6 +260,6 @@ func (r *releaser) release(soft bool) {
 		// fresh goroutine and signal the current read loop to return. A soft release
 		// (the handler returned) needs no action; the read loop continues inline.
 		r.handedOff = true
-		go r.conn.readIncoming(r.ctx, r.handler)
+		go r.conn.readIncoming(r.ctx)
 	}
 }

--- a/handler.go
+++ b/handler.go
@@ -39,6 +39,15 @@ import (
 //     surfaced through [Conn.Err] rather than silently swallowed.
 type Handler func(ctx context.Context, reply Replier, req Request) error
 
+// HandlerV2 is the direct-return handler shape: the returned result (or error)
+// becomes the call's response, so dispatch needs no per-request reply closure.
+// The request is a concrete value embedded in the connection's per-request
+// bookkeeping; its method and params are borrowed and valid until the handler
+// returns. For a notification the result is discarded and a non-nil error
+// fails the connection, matching the [Handler] contract for handler-returned
+// errors.
+type HandlerV2 func(ctx context.Context, req *RequestV2) (result any, err error)
+
 // Replier sends the reply to a [Request]. It is passed to a [Handler] and must
 // be called exactly once for a [*Call].
 //
@@ -196,6 +205,12 @@ type releaser struct {
 	// ch, when non-nil, marks the batch-member mode: release closes it.
 	ch chan struct{}
 
+	// ir points back to the request this releaser belongs to. A hard release
+	// (Async) is the single escape point at which a request outlives the frame
+	// it borrows from, so release clones the request's borrowed spans in place
+	// before the read loop can advance to the next frame.
+	ir *incomingRequest
+
 	// The remaining fields drive the inline single-message handoff (ch == nil).
 	conn     *conn
 	handler  Handler
@@ -227,6 +242,15 @@ func (r *releaser) release(soft bool) {
 	}
 	r.released = true
 	r.mu.Unlock()
+
+	if !soft && r.ir != nil {
+		// The handler is detaching from the read loop, so the borrowed method and
+		// params spans must stop aliasing the transport frame before the loop can
+		// read (and thereby invalidate) the next frame. Cloning here -- before the
+		// successor reader starts or the batch dispatch loop resumes -- is what
+		// makes the hard release the single legal escape point for a request.
+		r.ir.cloneRequestOwned()
+	}
 
 	switch {
 	case r.ch != nil:

--- a/handler.go
+++ b/handler.go
@@ -46,7 +46,33 @@ type Handler func(ctx context.Context, reply Replier, req Request) error
 // returns. For a notification the result is discarded and a non-nil error
 // fails the connection, matching the [Handler] contract for handler-returned
 // errors.
+//
+// Lifetime contract: req, its Method, and its Params are valid only until the
+// handler returns; the struct is recycled afterward. The three legal retention
+// patterns are:
+//
+//  1. Copy what you need before returning (unmarshal params, copy the method).
+//  2. Take [RequestV2.Clone] and retain the owned clone.
+//  3. Release with [Async], which clones the request in place automatically;
+//     the request then remains valid until the (now concurrent) handler
+//     returns.
+//
+// The per-request ctx likewise dies with the handler; use [DetachContext] for
+// work that outlives it. Builds tagged jsonrpc2poison scribble recycled
+// requests so violations fail loudly in tests.
 type HandlerV2 func(ctx context.Context, req *RequestV2) (result any, err error)
+
+// DetachContext returns a context that is safe to retain after the handler
+// returns. The per-request context handed to a handler is pooled and recycled
+// with the request, so retaining it past the handler's return is illegal;
+// DetachContext steps up to the connection-lifetime parent, keeping its values
+// and deadline but dropping the request-scoped cancellation.
+func DetachContext(ctx context.Context) context.Context {
+	if ir, ok := ctx.(*incomingRequest); ok {
+		return ir.parent
+	}
+	return ctx
+}
 
 // Replier sends the reply to a [Request]. It is passed to a [Handler] and must
 // be called exactly once for a [*Call].

--- a/handler_test.go
+++ b/handler_test.go
@@ -11,62 +11,32 @@ import (
 
 func TestMethodNotFoundHandler(t *testing.T) {
 	t.Parallel()
-	var gotErr error
-	reply := func(ctx context.Context, result any, err error) error {
-		gotErr = err
-		return nil
-	}
-	req := NewCall(NewNumberID(1), "missing", nil)
-	if err := MethodNotFoundHandler(t.Context(), reply, req); err != nil {
-		t.Fatalf("handler returned %v", err)
-	}
-	if !errors.Is(gotErr, ErrMethodNotFound) {
-		t.Fatalf("reply error: got %v want ErrMethodNotFound", gotErr)
-	}
-}
-
-func TestReplyHandler(t *testing.T) {
-	t.Parallel()
-	noopReply := func(ctx context.Context, result any, err error) error { return nil }
-	req := NewCall(NewNumberID(1), "m", nil)
 
 	tests := map[string]struct {
-		inner     Handler
-		wantPanic bool
+		req     Request
+		wantErr bool
 	}{
-		"success: replies exactly once": {
-			inner: func(ctx context.Context, reply Replier, req Request) error {
-				return reply(ctx, nil, nil)
-			},
-			wantPanic: false,
+		"error: call is answered with ErrMethodNotFound": {
+			req:     Request{id: NewNumberID(1), method: "missing", isCall: true},
+			wantErr: true,
 		},
-		"error: never replies": {
-			inner: func(ctx context.Context, reply Replier, req Request) error {
-				return nil
-			},
-			wantPanic: true,
-		},
-		"error: replies twice": {
-			inner: func(ctx context.Context, reply Replier, req Request) error {
-				_ = reply(ctx, nil, nil)
-				return reply(ctx, nil, nil)
-			},
-			wantPanic: true,
+		"success: notification is dropped without failing the connection": {
+			req: Request{method: "missing"},
 		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			h := ReplyHandler(tt.inner)
-			defer func() {
-				r := recover()
-				if tt.wantPanic && r == nil {
-					t.Fatal("expected a panic, got none")
-				}
-				if !tt.wantPanic && r != nil {
-					t.Fatalf("unexpected panic: %v", r)
-				}
-			}()
-			_ = h(t.Context(), noopReply, req)
+			t.Parallel()
+			result, err := MethodNotFoundHandler(t.Context(), &tt.req)
+			if result != nil {
+				t.Fatalf("result = %v, want nil", result)
+			}
+			if tt.wantErr && !errors.Is(err, ErrMethodNotFound) {
+				t.Fatalf("err = %v, want ErrMethodNotFound", err)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("err = %v, want nil for a notification", err)
+			}
 		})
 	}
 }

--- a/internal/benchmark/RESULTS.md
+++ b/internal/benchmark/RESULTS.md
@@ -134,6 +134,44 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 > large-row gate on the channel family, confirming the copy-bound thesis via
 > the GC-pressure mechanism the Phase-0 profile predicted.
 
+> **Update — Round 6 v2 component kill-tests A1/A2/A3/A4 + combined C gate:
+> ALL KEEP (2026-06-12).** Raw artifacts:
+> `internal/benchmark/artifacts/20260612T*-r6-a1-direct-return-kill-test`,
+> `...-r6-a2-c-combined-kill-test`, `...-r6-a3-scan-into-value-kill-test`,
+> `...-r6-a4-pooled-ir-kill-test` (all `-benchmem -count=10` vs the Round-6
+> Phase-0 baseline; internal rows under `GOWORK=off GOFLAGS=-mod=mod`).
+> Staged on top of the kept R6-B tree, the four v2 components each passed
+> their pre-registered gate on root `BenchmarkVoidRoundTrip`:
+> **A1 direct-return** (`HandlerV2`, no reply closure) 4 -> 3 allocs/op,
+> 308 -> 244 B/op, ns neutral (p=0.796) — the Round-5 L3b B/op regression
+> does not recur; **A2 borrowed method/params** (`unsafe.String` span borrow
+> + params alias) 3 -> 2 allocs/op, and on the internal families params rows
+> dropped two further allocs each (native 13 -> 9 with B, common 8 -> 6) with
+> native notify 4 -> 2; **A3 scan-into-value** (concrete `RequestV2` embedded
+> in the per-request struct, no `&Call{}` box) 2 -> 1 alloc/op, 256 B/op,
+> ns **-8.74%** (p=0.000); **A4 pooled request** (`irPool`, full field reset,
+> Async-detached requests never pooled) — **0 allocs/op, 0 B/op, ns -14.45%**
+> (`2.914 us +/-1%` -> `2.493 us +/-12%`, p=0.000). The **C combined gate**
+> (A2+B) passed on BOTH transport families: `RoundTripParams/large` native
+> **-29.41%** (`7.044 us` -> `4.972 us`), common **-10.91%** (`9.455 us` ->
+> `8.423 us`), small/medium rows -4.60% to -17.02%, no valid small-row
+> regression — the large-row copy-bound thesis is confirmed through the
+> GC-pressure mechanism the Phase-0 profile predicted (cloneBytes was 93.7%
+> of alloc_space; codec < 2%, so the conditional R6-E codec lever is closed).
+> Safety findings recorded with the artifacts: (1) `-race` caught the
+> Async-retention hazard exactly as pre-mortem'd — an `AsyncHandler` reading
+> borrowed params while the successor reader refilled the buffer — fixed by
+> making the hard release the single escape point (`cloneRequestOwned` runs
+> before the successor reader starts or the batch loop resumes); (2) the
+> `jsonrpc2poison` build scribbles pooled requests and its retention test
+> passes loudly (retention also trips `-race`, which is the intended
+> defense-in-depth); (3) `TestDecodeMessage_OwnsBuffer` fails by design while
+> the borrowed-span contract replaces owns-bytes — the v2 surface work
+> rewrites that contract and test. net.Pipe rows showed late-in-batch
+> anomalies (+66%/+68%) that vanish in isolation reruns (~neutral/-6%);
+> isolation runs are the binding measurements, consistent with Round 5's
+> recorded load/order sensitivity.
+
 > **Update — Round 5 Phase 4 final docs and linux/amd64 refresh (2026-06-10).**
 > Raw artifact:
 > `internal/benchmark/artifacts/20260610T113339Z-g011-linux-amd64-final`.

--- a/internal/benchmark/RESULTS.md
+++ b/internal/benchmark/RESULTS.md
@@ -76,6 +76,64 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 >   by an interface change to `Replier` that damages every handler call site for
 >   no ns gain.
 
+> **Update — Round 6 Phase 0 baseline + common-row harness correction
+> (2026-06-12).** Raw artifact:
+> `internal/benchmark/artifacts/20260612T031259Z-r6-baseline` (root + full
+> internal suite `-benchmem -count=10`, Go `go1.26.4 darwin/arm64`, Apple M3
+> Max, HEAD `7147e05`,
+> `GOEXPERIMENT=runtimefreegc,sizespecializedmalloc,runtimesecret`).
+> **Harness integrity correction:** Round 5's `a28452c` switched the shared
+> `newJSONRPC2Adapter` to `NewChannelStreamPair`, so every `jsonrpc2/common`
+> row silently measured the channel transport while jrpc2/mcp common rows
+> stayed on net.Pipe — the documented same-transport contract did not hold.
+> Fixed in `5a0a824` (`newJSONRPC2CommonAdapter`, net.Pipe + NDJSON); the
+> corrected common baseline is
+> `internal-benchmark-common-corrected.txt` (void `2.910 us`/336 B/6 allocs,
+> notify `1.034 us`/3 allocs, params large `9.514 us`/9 allocs). Round 5's
+> recorded common-row deltas (e.g. "common void -41.58%") were channel-backed
+> and are superseded. **A second harness hazard recorded for the protocol:**
+> the nested benchmark module vendors `go.lsp.dev/jsonrpc2`, so plain
+> `go test` builds run `-mod=vendor` against the vendored snapshot, not the
+> working tree; every Round 6 spike run uses `GOWORK=off GOFLAGS=-mod=mod`
+> (the same mode `bench-artifacts.sh` forces). Phase-0 numbers are valid
+> because vendor == HEAD at capture. **Phase-0 anchors (arm64):** root
+> `BenchmarkVoidRoundTrip` `2.914 us +/-1%`/308 B/4 allocs; channel-native
+> void `1.972 us`/640 B/11 allocs; notify native `681 ns`/4 allocs; params
+> large native `7.255 us`/9.36 KiB/13 allocs. Alloc census matches the
+> Round-6 plan exactly (replier closure 31.5%, `&Call{}` box 30.2%,
+> `incomingRequest` 28.2%, method string 9.8% of root-void objects).
+> **R6-C adjudication:** params-large CPU is ~87.6% scheduling, GC tax ~6-8%
+> (clone garbage: `cloneBytes` = 93.7% of alloc_space), codec < 2%, memmove
+> < 0.5% — the params-codec lever (R6-E) stays closed and no new asm is
+> justified (no compute-bound component >= 5% on any claim row).
+
+> **Update — Round 6 R6-B channel ownership-handoff kill-test: KEEP
+> (2026-06-12).** Raw artifact:
+> `internal/benchmark/artifacts/20260612T041514Z-r6-b-ownership-kill-test`
+> (`GOWORK=off GOFLAGS=-mod=mod go test -run '^$' -bench
+> '<channel-native rows>' -benchmem -count=10`, vs the Phase-0 anchors above).
+> The kept form replaces clone-on-queue with pooled-frame ownership transfer:
+> frames are `sync.Pool`-recycled `*frameBuf` boxes composed by the sender,
+> handed through the data channel, and recycled by the receiver at its next
+> read ("valid until next read", the documented frameStream contract);
+> `writeMu` is retained as a sender breakwater in front of the channel send.
+> Gate result on the channel-native family: `RoundTripVoid` ns neutral
+> (`1.973 us +/-3%` -> `1.977 us +/-1%`, p=0.362) with **11 -> 9 allocs/op,
+> 640 -> 546 B/op**; `RoundTripVoidParallel` **P4 -11.31%, P12 -7.86%**;
+> `RoundTripParams` small **-4.60%**, medium **-6.96%**, large **-20.83% ns,
+> -51.18% B/op** (9.36 KiB -> 4.57 KiB), all params rows -2 allocs;
+> `Notify` ns neutral, **4 -> 3 allocs**; `Batch` n1 -1.87%, n4 -0.58%,
+> n16 -3.10%; geomean **-5.98%**; no channel row regressed. Two rejected
+> forms are recorded with the artifact: a per-direction free-list channel
+> (P12 +42.59%) and the pool without the sender mutex (P12 +21.93%) — both
+> died of select-lock contention (`runtime.sellock` 34.5% of P12 CPU), which
+> is why the breakwater mutex stays. One `-race` finding during the spike:
+> the frame's length must be read before the channel send, because ownership
+> transfers at the send and a fast receiver can recycle the box before the
+> sender returns. Large-row note: B alone already clears the R6-C >= 10%
+> large-row gate on the channel family, confirming the copy-bound thesis via
+> the GC-pressure mechanism the Phase-0 profile predicted.
+
 > **Update — Round 5 Phase 4 final docs and linux/amd64 refresh (2026-06-10).**
 > Raw artifact:
 > `internal/benchmark/artifacts/20260610T113339Z-g011-linux-amd64-final`.

--- a/internal/benchmark/RESULTS.md
+++ b/internal/benchmark/RESULTS.md
@@ -78,7 +78,7 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 
 > **Update — Round 6 Phases 2-4: consolidated direct-return surface, final
 > combined gate (2026-06-12).** Raw artifact:
-> `internal/benchmark/artifacts/20260612T063407Z-r6-phase3-final-gate`
+> `internal/benchmark/artifacts/20260612T072858Z-r6-phase3-final-gate`
 > (root + internal `-benchmem -count=10`, HEAD `6f3bcfc`; two superseded gate
 > datasets retained alongside). Phase 2 shipped the survivors as ONE break,
 > then — per the maintainer's in-flight direction to drop every `V2` name —
@@ -121,6 +121,51 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 > (`PipelineClientVoidRoundTrip` -6.7% to -10.0%). (3) The linux/amd64
 > confirmation leg did not run in this session (no CI/remote access);
 > AC-R6-3's second-arch check is deferred to the next amd64 refresh.
+> (4) Wire-behavior delta of the direct-return shape: a call handler that
+> returns the zero values now answers with a SUCCESS response carrying a
+> null result, because the unanswered-call state ("returned without
+> replying" -> InternalError) is unrepresentable when the return values ARE
+> the reply. Spec-valid and judged an improvement by the architecture
+> review, but downstream callers that matched the old InternalError must
+> adjust (robustness_test.go records both sides of the change).
+>
+> **Ralph current-HEAD verification refresh (2026-06-20).** Raw artifact:
+> `internal/benchmark/artifacts/20260620T022736Z-r6-ralph-current-head-verification`
+> (ignored artifact directory, HEAD `425922c`). This refresh records current
+> evidence for the two documentation-only commits that landed after the
+> 2026-06-12 final gate. Local darwin/arm64 reruns on Go `go1.26.4` with
+> `GOEXPERIMENT=runtimefreegc,sizespecializedmalloc,runtimesecret` keep the
+> root `BenchmarkVoidRoundTrip` floor at **0 B/op, 0 allocs/op** (focused
+> count=3 samples: 2.982-2.989 us), channel-native void at **236 B/op,
+> 5 allocs/op**, params-large native at **261 B/op, 6 allocs/op**, and
+> `Notify` at **0 B/op, 0 allocs/op** on both jsonrpc2 families. The linux/amd64
+> leg was refreshed with a temporary bundle clone of the same HEAD on
+> `debian-13-trixie-mnx1` (`go1.26.4 linux/amd64`, Intel Xeon Platinum 8481C):
+> root void remains **0 B/op, 0 allocs/op** (4.114-4.528 us), channel-native
+> void is **238 B/op, 5 allocs/op**, params-large native is **263 B/op,
+> 6 allocs/op**, and `Notify` is **0 B/op, 0 allocs/op** on both jsonrpc2
+> families. Fresh correctness gates also passed in this Ralph run: local
+> `go test -mod=mod ./...`, `go test -mod=mod -race -count=2 .`, poison-build
+> retention test, `go vet ./...`, `git diff --check`, root-module `gopls check`,
+> internal benchmark tests, and linux/amd64 root tests on the temp clone.
+
+> **Next-plan reconciliation (Ralph, 2026-06-20).** Raw artifact:
+> `internal/benchmark/artifacts/20260620T032629Z-next-viable-plan-reconciliation`
+> (ignored artifact directory, HEAD `425922c`). The requested "next viable
+> unexecuted performance plan" set was reconciled against current HEAD in order:
+> `.omc/plans/next-layer-perf-optimization.md`,
+> `.omc/plans/world-fastest-jsonrpc2-rewrite.md`,
+> `.omx/plans/jsonrpc2-netpoll-gnet-server-mode-probe-plan-20260606.md`,
+> `.omc/plans/zero-alloc-v2-perf-round6.md`,
+> `.omc/plans/unlocked-levers-perf-round.md`, and this RESULTS ledger. No
+> additional implementation remains in that candidate set without a new
+> mechanism class: the next-layer allocation/sync/borrow/direct-mode/SIMD
+> levers were shipped, superseded, or killed by Rounds 5-6; the rewrite plan is
+> the architecture now represented by the current code and benchmark harness;
+> and the netpoll/gnet server probe is already implemented as benchmark-only
+> rows with both production candidates rejected for adoption below. This entry
+> exists to prevent future runs from re-opening stale plan files as if they were
+> unexecuted implementation work.
 
 > **Update — Round 6 Phase 0 baseline + common-row harness correction
 > (2026-06-12).** Raw artifact:

--- a/internal/benchmark/RESULTS.md
+++ b/internal/benchmark/RESULTS.md
@@ -76,6 +76,52 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 >   by an interface change to `Replier` that damages every handler call site for
 >   no ns gain.
 
+> **Update — Round 6 Phases 2-4: consolidated direct-return surface, final
+> combined gate (2026-06-12).** Raw artifact:
+> `internal/benchmark/artifacts/20260612T063407Z-r6-phase3-final-gate`
+> (root + internal `-benchmem -count=10`, HEAD `6f3bcfc`; two superseded gate
+> datasets retained alongside). Phase 2 shipped the survivors as ONE break,
+> then — per the maintainer's in-flight direction to drop every `V2` name —
+> the direct-return shape became THE API: the concrete struct is `Request`
+> (the wire-model interface is `RequestMessage`), `Handler` is
+> `func(ctx, *Request) (any, error)`, `Conn.Go` dispatches direct-return on
+> every connection, and `Replier`, `ReplyHandler`, `GoDirect`, and the whole
+> reply-closure machinery are deleted; batch members, the Preempter, and the
+> non-frame fallback flow through the same pooled request. `readNext` then
+> collapsed to a single classification scan per frame (one `scanObject` pass
+> serves request fill AND borrowed-result response delivery), which removed
+> the double scan client connections paid per response. Safety findings fixed
+> during the consolidation, all caught by `-race`: the batch gate channel is
+> captured before the member goroutine starts; the pool reset is factored out
+> of the put so tests never read a pooled struct; frame length reads precede
+> channel handoff. **Final claim rows (arm64, count=10 means, vs Phase 0):**
+> root `BenchmarkVoidRoundTrip` **2.480 us +/-5% (-14.88%), 0 B/op, 0
+> allocs/op**; channel-native void `1.831 us` (-7.17%), 236 B, **11 -> 5
+> allocs**; common void `2.835 us`, 28 B, 6 -> 2 allocs; `Notify` **0 B / 0
+> allocs on BOTH families** (native `584 ns` -14.29%, common `877 ns`
+> -14.70%); `RoundTripParams/large` native `5.068 us` (**-27.66%**, B/op
+> 9.36 KiB -> **262 B**), common -10.88%; `Batch/n16` **-55.8% / -54.4%**;
+> parallel P4/P12 native **-22.9% / -21.8%**; `ConnPipelined/Inflight1`
+> **0 B / 0 allocs** at -3.25%. Cross-library: jsonrpc2 is fastest by sec/op
+> mean on **27 of 27** apples-to-apples rows (`fastest-check.txt`).
+> Verification: `-race -count=2 .` green including the named concurrency
+> suites, conformance vectors green, `FuzzScan`/`FuzzRoundTrip` 30 s clean,
+> poison-build retention tests green. **Disclosures:** (1)
+> `ConnPipelinedVoidRoundTrip/Inflight256` regressed **+8.52%** (1.248 ms
+> +/-11% -> 1.354 ms +/-2%) while its allocations fell 1296 -> 261 and B/op
+> 97.4 KiB -> 17.6 KiB; the profile is 97.4% scheduling with `lock2` 31.8% +
+> `Mutex.lockSlow` 18.5% under `guardedWrite` — a 256-writer write-mutex
+> convoy that GC pauses no longer break up after the allocation wins. The
+> only fix class (write coalescing) is permanently banned by the Round-5
+> carry-forward ledger, so the row ships as a transparent cost note; every
+> shallower depth improves. (2) Parser micro guard rows
+> (`DecodeEnvelope/Response` +6.18%, `/ErrorResponse` +4.93%, DecodeView
+> rows <= +3.7%) drift by code layout; no Round-6 lever touches those paths
+> and the full-RPC response path improved everywhere
+> (`PipelineClientVoidRoundTrip` -6.7% to -10.0%). (3) The linux/amd64
+> confirmation leg did not run in this session (no CI/remote access);
+> AC-R6-3's second-arch check is deferred to the next amd64 refresh.
+
 > **Update — Round 6 Phase 0 baseline + common-row harness correction
 > (2026-06-12).** Raw artifact:
 > `internal/benchmark/artifacts/20260612T031259Z-r6-baseline` (root + full

--- a/internal/benchmark/RESULTS.md
+++ b/internal/benchmark/RESULTS.md
@@ -9,14 +9,14 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 > root `BenchmarkVoidRoundTrip`). A subsequent best-effort optimization pass cut
 > the void round-trip to **10 allocs/op** on the root bench (≈ **12 allocs/op**
 > through this harness, which additionally decodes the response into a
-> `RawMessage`) and ≈ **3000 ns/op** (from ≈ 4850 ns/op), preserving the §3.3
+> `RawMessage`) and ≈ **3000 ns/op** (from ≈ 4850 ns/op), preserving the
 > single-copy single-owner ownership invariant and keeping `go test -race
 > -count=2 .` green. The four kept optimizations are documented in the
 > [Optimization log](#optimization-log-hot-path-allocations) below, and every
 > table in this file now reflects the **AFTER** numbers. The `Decode` /
 > `ParseRequests` numbers are unchanged because those standalone entry points
 > were intentionally left at their documented allocation floors (see the
-> [decode floor note](#decode-allocation-floor-ac-p2--ac-p4-status)).
+> [decode floor note](#decode-allocation-floor)).
 
 > **Update — next-layer optimization pass (this pass).** A further pass cut the
 > root `BenchmarkVoidRoundTrip` from **10 → 6 allocs/op** and **572 → 408 B/op**
@@ -40,17 +40,17 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 >   explicitly **not** done: it would buy only one more alloc, is the sole
 >   use-after-free source, and `-race` cannot detect a `sync.Pool` use-after-
 >   recycle because `Pool.Get`/`Put` synchronize internally.) **−2 allocs/op.**
-> - **New — `SyncClient` (A1c caller-pumps-the-reader).** A distinct synchronous-
+> - **New — `SyncClient` (caller-pumps-the-reader).** A distinct synchronous-
 >   client mode that owns its read loop instead of running a background reader, so
 >   a `Call` collapses the third goroutine hop. **~2030 ns/op vs the `Conn` round
 >   trip's ~2900 ns** on the same `net.Pipe`+NDJSON transport. Reported as a
 >   separate `jsonrpc2/sync` row with mode disclosure (see
->   [Synchronous-client mode](#synchronous-client-mode-a1c)); it is **not** a
+>   [Synchronous-client mode](#synchronous-client-mode)); it is **not** a
 >   head-to-head claim against `channel.Direct` and **not** a speedup of the
 >   bidirectional `Conn`.
-> - **Rejected on measurement — atomic shutdown fast path (A2).** An atomic
+> - **Rejected on measurement — atomic shutdown fast path.** An atomic
 >   "shutting down" latch was implemented to skip the `stateMu` acquisition on the
->   read-only `shuttingDown` check in the write path. A clean A2-off vs A2-on
+>   read-only `shuttingDown` check in the write path. A clean off-vs-on
 >   isolation (same code state, `-count=8`) was **statistically indistinguishable**
 >   (~3679–3786 vs ~3656–3899 ns at P4/P12). The parallel path is scheduling-bound
 >   (the CPU profile is 56% `pthread_cond_wait` + 26% `cond_signal`); the `stateMu`
@@ -76,12 +76,12 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 >   by an interface change to `Replier` that damages every handler call site for
 >   no ns gain.
 
-> **Update — Round 6 Phases 2-4: consolidated direct-return surface, final
+> **Update — consolidated direct-return surface, final
 > combined gate (2026-06-12).** Raw artifact:
 > `internal/benchmark/artifacts/20260612T072858Z-r6-phase3-final-gate`
 > (root + internal `-benchmem -count=10`, HEAD `6f3bcfc`; two superseded gate
-> datasets retained alongside). Phase 2 shipped the survivors as ONE break,
-> then — per the maintainer's in-flight direction to drop every `V2` name —
+> datasets retained alongside). This round shipped the survivors as ONE break,
+> then — per the maintainer's in-flight direction to drop every second-generation API name —
 > the direct-return shape became THE API: the concrete struct is `Request`
 > (the wire-model interface is `RequestMessage`), `Handler` is
 > `func(ctx, *Request) (any, error)`, `Conn.Go` dispatches direct-return on
@@ -94,7 +94,7 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 > during the consolidation, all caught by `-race`: the batch gate channel is
 > captured before the member goroutine starts; the pool reset is factored out
 > of the put so tests never read a pooled struct; frame length reads precede
-> channel handoff. **Final claim rows (arm64, count=10 means, vs Phase 0):**
+> channel handoff. **Final claim rows (arm64, count=10 means, vs the baseline):**
 > root `BenchmarkVoidRoundTrip` **2.480 us +/-5% (-14.88%), 0 B/op, 0
 > allocs/op**; channel-native void `1.831 us` (-7.17%), 236 B, **11 -> 5
 > allocs**; common void `2.835 us`, 28 B, 6 -> 2 allocs; `Notify` **0 B / 0
@@ -112,15 +112,15 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 > 97.4 KiB -> 17.6 KiB; the profile is 97.4% scheduling with `lock2` 31.8% +
 > `Mutex.lockSlow` 18.5% under `guardedWrite` — a 256-writer write-mutex
 > convoy that GC pauses no longer break up after the allocation wins. The
-> only fix class (write coalescing) is permanently banned by the Round-5
-> carry-forward ledger, so the row ships as a transparent cost note; every
+> only fix class (write coalescing) is permanently banned by the carry-forward
+> ledger from the earlier optimization round, so the row ships as a transparent cost note; every
 > shallower depth improves. (2) Parser micro guard rows
 > (`DecodeEnvelope/Response` +6.18%, `/ErrorResponse` +4.93%, DecodeView
-> rows <= +3.7%) drift by code layout; no Round-6 lever touches those paths
+> rows <= +3.7%) drift by code layout; no lever in this optimization round touches those paths
 > and the full-RPC response path improved everywhere
 > (`PipelineClientVoidRoundTrip` -6.7% to -10.0%). (3) The linux/amd64
 > confirmation leg did not run in this session (no CI/remote access);
-> AC-R6-3's second-arch check is deferred to the next amd64 refresh.
+> the second-architecture (linux/amd64) confirmation is deferred to the next amd64 refresh.
 > (4) Wire-behavior delta of the direct-return shape: a call handler that
 > returns the zero values now answers with a SUCCESS response carrying a
 > null result, because the unanswered-call state ("returned without
@@ -152,57 +152,55 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 > **Next-plan reconciliation (Ralph, 2026-06-20).** Raw artifact:
 > `internal/benchmark/artifacts/20260620T032629Z-next-viable-plan-reconciliation`
 > (ignored artifact directory, HEAD `425922c`). The requested "next viable
-> unexecuted performance plan" set was reconciled against current HEAD in order:
-> `.omc/plans/next-layer-perf-optimization.md`,
-> `.omc/plans/world-fastest-jsonrpc2-rewrite.md`,
-> `.omx/plans/jsonrpc2-netpoll-gnet-server-mode-probe-plan-20260606.md`,
-> `.omc/plans/zero-alloc-v2-perf-round6.md`,
-> `.omc/plans/unlocked-levers-perf-round.md`, and this RESULTS ledger. No
+> unexecuted performance plan" set — the next-layer allocation/sync/borrow
+> optimization work, the world-fastest rewrite, the netpoll/gnet socket-server
+> mode probe, the zero-alloc direct-return surface, and the unlocked-levers
+> round — was reconciled against current HEAD alongside this RESULTS ledger. No
 > additional implementation remains in that candidate set without a new
 > mechanism class: the next-layer allocation/sync/borrow/direct-mode/SIMD
-> levers were shipped, superseded, or killed by Rounds 5-6; the rewrite plan is
+> levers were shipped, superseded, or killed by the earlier optimization rounds; the rewrite plan is
 > the architecture now represented by the current code and benchmark harness;
 > and the netpoll/gnet server probe is already implemented as benchmark-only
 > rows with both production candidates rejected for adoption below. This entry
 > exists to prevent future runs from re-opening stale plan files as if they were
 > unexecuted implementation work.
 
-> **Update — Round 6 Phase 0 baseline + common-row harness correction
+> **Update — baseline + common-row harness correction
 > (2026-06-12).** Raw artifact:
 > `internal/benchmark/artifacts/20260612T031259Z-r6-baseline` (root + full
 > internal suite `-benchmem -count=10`, Go `go1.26.4 darwin/arm64`, Apple M3
 > Max, HEAD `7147e05`,
 > `GOEXPERIMENT=runtimefreegc,sizespecializedmalloc,runtimesecret`).
-> **Harness integrity correction:** Round 5's `a28452c` switched the shared
+> **Harness integrity correction:** An earlier optimization round's `a28452c` switched the shared
 > `newJSONRPC2Adapter` to `NewChannelStreamPair`, so every `jsonrpc2/common`
 > row silently measured the channel transport while jrpc2/mcp common rows
 > stayed on net.Pipe — the documented same-transport contract did not hold.
 > Fixed in `5a0a824` (`newJSONRPC2CommonAdapter`, net.Pipe + NDJSON); the
 > corrected common baseline is
 > `internal-benchmark-common-corrected.txt` (void `2.910 us`/336 B/6 allocs,
-> notify `1.034 us`/3 allocs, params large `9.514 us`/9 allocs). Round 5's
+> notify `1.034 us`/3 allocs, params large `9.514 us`/9 allocs). The earlier optimization round's
 > recorded common-row deltas (e.g. "common void -41.58%") were channel-backed
 > and are superseded. **A second harness hazard recorded for the protocol:**
 > the nested benchmark module vendors `go.lsp.dev/jsonrpc2`, so plain
 > `go test` builds run `-mod=vendor` against the vendored snapshot, not the
-> working tree; every Round 6 spike run uses `GOWORK=off GOFLAGS=-mod=mod`
-> (the same mode `bench-artifacts.sh` forces). Phase-0 numbers are valid
-> because vendor == HEAD at capture. **Phase-0 anchors (arm64):** root
+> working tree; every spike run in this optimization round uses `GOWORK=off GOFLAGS=-mod=mod`
+> (the same mode `bench-artifacts.sh` forces). Baseline numbers are valid
+> because vendor == HEAD at capture. **Baseline anchors (arm64):** root
 > `BenchmarkVoidRoundTrip` `2.914 us +/-1%`/308 B/4 allocs; channel-native
 > void `1.972 us`/640 B/11 allocs; notify native `681 ns`/4 allocs; params
 > large native `7.255 us`/9.36 KiB/13 allocs. Alloc census matches the
-> Round-6 plan exactly (replier closure 31.5%, `&Call{}` box 30.2%,
+> planned census for this optimization round exactly (replier closure 31.5%, `&Call{}` box 30.2%,
 > `incomingRequest` 28.2%, method string 9.8% of root-void objects).
-> **R6-C adjudication:** params-large CPU is ~87.6% scheduling, GC tax ~6-8%
+> **Copy-bound large-row adjudication:** params-large CPU is ~87.6% scheduling, GC tax ~6-8%
 > (clone garbage: `cloneBytes` = 93.7% of alloc_space), codec < 2%, memmove
-> < 0.5% — the params-codec lever (R6-E) stays closed and no new asm is
+> < 0.5% — the params-codec lever stays closed and no new asm is
 > justified (no compute-bound component >= 5% on any claim row).
 
-> **Update — Round 6 R6-B channel ownership-handoff kill-test: KEEP
+> **Update — channel ownership-handoff kill-test: KEEP
 > (2026-06-12).** Raw artifact:
 > `internal/benchmark/artifacts/20260612T041514Z-r6-b-ownership-kill-test`
 > (`GOWORK=off GOFLAGS=-mod=mod go test -run '^$' -bench
-> '<channel-native rows>' -benchmem -count=10`, vs the Phase-0 anchors above).
+> '<channel-native rows>' -benchmem -count=10`, vs the baseline anchors above).
 > The kept form replaces clone-on-queue with pooled-frame ownership transfer:
 > frames are `sync.Pool`-recycled `*frameBuf` boxes composed by the sender,
 > handed through the data channel, and recycled by the receiver at its next
@@ -221,34 +219,34 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 > is why the breakwater mutex stays. One `-race` finding during the spike:
 > the frame's length must be read before the channel send, because ownership
 > transfers at the send and a fast receiver can recycle the box before the
-> sender returns. Large-row note: B alone already clears the R6-C >= 10%
+> sender returns. Large-row note: B alone already clears the >= 10%
 > large-row gate on the channel family, confirming the copy-bound thesis via
-> the GC-pressure mechanism the Phase-0 profile predicted.
+> the GC-pressure mechanism the baseline profile predicted.
 
-> **Update — Round 6 v2 component kill-tests A1/A2/A3/A4 + combined C gate:
+> **Update — second-generation direct-return component kill-tests + combined gate:
 > ALL KEEP (2026-06-12).** Raw artifacts:
 > `internal/benchmark/artifacts/20260612T*-r6-a1-direct-return-kill-test`,
 > `...-r6-a2-c-combined-kill-test`, `...-r6-a3-scan-into-value-kill-test`,
-> `...-r6-a4-pooled-ir-kill-test` (all `-benchmem -count=10` vs the Round-6
-> Phase-0 baseline; internal rows under `GOWORK=off GOFLAGS=-mod=mod`).
-> Staged on top of the kept R6-B tree, the four v2 components each passed
+> `...-r6-a4-pooled-ir-kill-test` (all `-benchmem -count=10` vs the
+> baseline; internal rows under `GOWORK=off GOFLAGS=-mod=mod`).
+> Staged on top of the kept channel-ownership-handoff tree, the four second-generation components each passed
 > their pre-registered gate on root `BenchmarkVoidRoundTrip`:
-> **A1 direct-return** (`HandlerV2`, no reply closure) 4 -> 3 allocs/op,
-> 308 -> 244 B/op, ns neutral (p=0.796) — the Round-5 L3b B/op regression
-> does not recur; **A2 borrowed method/params** (`unsafe.String` span borrow
+> **Direct-return** (`HandlerV2`, no reply closure) 4 -> 3 allocs/op,
+> 308 -> 244 B/op, ns neutral (p=0.796) — the replier/typed-Replier API change's B/op regression from the earlier optimization round
+> does not recur; **Borrowed method/params** (`unsafe.String` span borrow
 > + params alias) 3 -> 2 allocs/op, and on the internal families params rows
 > dropped two further allocs each (native 13 -> 9 with B, common 8 -> 6) with
-> native notify 4 -> 2; **A3 scan-into-value** (concrete `RequestV2` embedded
+> native notify 4 -> 2; **Scan-into-value** (concrete `RequestV2` embedded
 > in the per-request struct, no `&Call{}` box) 2 -> 1 alloc/op, 256 B/op,
-> ns **-8.74%** (p=0.000); **A4 pooled request** (`irPool`, full field reset,
+> ns **-8.74%** (p=0.000); **Pooled request** (`irPool`, full field reset,
 > Async-detached requests never pooled) — **0 allocs/op, 0 B/op, ns -14.45%**
-> (`2.914 us +/-1%` -> `2.493 us +/-12%`, p=0.000). The **C combined gate**
-> (A2+B) passed on BOTH transport families: `RoundTripParams/large` native
+> (`2.914 us +/-1%` -> `2.493 us +/-12%`, p=0.000). The **combined gate**
+> (the borrowed method/params change plus the channel ownership-handoff change) passed on BOTH transport families: `RoundTripParams/large` native
 > **-29.41%** (`7.044 us` -> `4.972 us`), common **-10.91%** (`9.455 us` ->
 > `8.423 us`), small/medium rows -4.60% to -17.02%, no valid small-row
 > regression — the large-row copy-bound thesis is confirmed through the
-> GC-pressure mechanism the Phase-0 profile predicted (cloneBytes was 93.7%
-> of alloc_space; codec < 2%, so the conditional R6-E codec lever is closed).
+> GC-pressure mechanism the baseline profile predicted (cloneBytes was 93.7%
+> of alloc_space; codec < 2%, so the conditional codec lever is closed).
 > Safety findings recorded with the artifacts: (1) `-race` caught the
 > Async-retention hazard exactly as pre-mortem'd — an `AsyncHandler` reading
 > borrowed params while the successor reader refilled the buffer — fixed by
@@ -257,13 +255,13 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 > `jsonrpc2poison` build scribbles pooled requests and its retention test
 > passes loudly (retention also trips `-race`, which is the intended
 > defense-in-depth); (3) `TestDecodeMessage_OwnsBuffer` fails by design while
-> the borrowed-span contract replaces owns-bytes — the v2 surface work
+> the borrowed-span contract replaces owns-bytes — the second-generation surface work
 > rewrites that contract and test. net.Pipe rows showed late-in-batch
 > anomalies (+66%/+68%) that vanish in isolation reruns (~neutral/-6%);
-> isolation runs are the binding measurements, consistent with Round 5's
+> isolation runs are the binding measurements, consistent with the earlier optimization round's
 > recorded load/order sensitivity.
 
-> **Update — Round 5 Phase 4 final docs and linux/amd64 refresh (2026-06-10).**
+> **Update — final docs and linux/amd64 refresh (2026-06-10).**
 > Raw artifact:
 > `internal/benchmark/artifacts/20260610T113339Z-g011-linux-amd64-final`.
 > The final linux/amd64 run used an isolated remote temp workspace containing
@@ -287,7 +285,7 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 > review returned code-reviewer **APPROVE** and architect **CLEAR** after fixing
 > the earlier Conn scanner-fallback and channel-stream post-close blockers.
 
-> **Update — Round 5 Phase 3 combined regression gate (2026-06-10).**
+> **Update — combined regression gate (2026-06-10).**
 > Raw artifact:
 > `internal/benchmark/artifacts/20260610T111717Z-combined-regression-gate`.
 > Verdict: **PASS; no survivor was reverted.** Root affected rows pass the
@@ -295,44 +293,44 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 > `2.885 us +/-1%` (-2.45%) with `408 -> 324 B/op` and `6 -> 4
 > allocs/op`; `ConnPipelinedVoidRoundTrip/Inflight1` improved -4.15%;
 > Inflight8/64/256 were statistically neutral by benchstat. Internal affected
-> jsonrpc2 rows all improved by wall-clock vs Phase 0: native void
+> jsonrpc2 rows all improved by wall-clock vs the baseline: native void
 > `3.047 us +/-1%` -> `1.763 us +/-1%` (-42.13%), common void -41.58%,
 > params rows -30.69% to -62.57%, and notify rows -38.46% to -63.48%.
-> AC-P3 passes: `internal-affected-fastest-check.txt` shows jsonrpc2 fastest
+> The never-slower-than-rivals criterion passes: `internal-affected-fastest-check.txt` shows jsonrpc2 fastest
 > by sec/op mean on every final affected apples-to-apples row/family
 > (native/common void, P4/P12, params small/medium/large, and notify).
-> Disclosure for G011 docs: `NewChannelStreamPair` preserves queued-frame
+> Disclosure for the claim-table-refresh docs: `NewChannelStreamPair` preserves queued-frame
 > ownership by copying, so small/void/notify internal rows allocate more than
 > the old net.Pipe native rows (`RoundTripVoid` `436 -> 656 B/op`,
 > `8 -> 11 allocs/op`; `Notify` `228 -> 276 B/op`, `3 -> 4 allocs/op`).
 > The registered plan gates wall-clock only; allocation increases here are a
-> claim-table disclosure, not a G010 revert trigger. Verification passed
+> claim-table disclosure, not a combined-regression-gate revert trigger. Verification passed
 > `go test -race -count=2 .`, `go test ./...`, nested benchmark compile, and
 > `git diff --check`.
 
-> **Update — Round 5 Phase 2 survivor implementation (2026-06-10).**
+> **Update — survivor implementation (2026-06-10).**
 > Raw artifact:
-> `internal/benchmark/artifacts/20260610T111230Z-phase2-survivors`. Phase 2 implemented only graduated survivors. **L4** remains the
-> G006 direct-unmarshal path and now has a `64 KiB` result-size fallback so large
+> `internal/benchmark/artifacts/20260610T111230Z-phase2-survivors`. This round implemented only graduated survivors. **Direct-unmarshal** remains the
+> direct-unmarshal path and now has a `64 KiB` result-size fallback so large
 > responses use the owned `DecodeMessage` path instead of unmarshaling on the
-> read goroutine. **L1** graduated as `NewChannelStreamPair(capacity)`, a
+> read goroutine. **The channel transport** graduated as `NewChannelStreamPair(capacity)`, a
 > bounded in-memory encoded-frame stream pair with explicit `WriteFrame` copy
 > ownership and concrete `frameWriter` helpers for `Conn`. The internal native
 > benchmark adapter now uses `NewChannelStreamPair(1)` for `jsonrpc2/native`.
 > Native-row latency evidence is mixed under local load: the first re-anchor run
-> improved the Phase 0 net.Pipe native artifact (`3.047 us +/-1%` -> `1.783 us
+> improved the baseline net.Pipe native artifact (`3.047 us +/-1%` -> `1.783 us
 > +/-4%`, -41.47%), while the final exact-row smoke averaged **3008.6 ns/op**
-> versus the Phase 0 **3044.6 ns/op** mean. Memory cost increases in both runs
+> versus the baseline **3044.6 ns/op** mean. Memory cost increases in both runs
 > (`436 -> 656 B/op`, `8 -> 11 allocs/op`) because the bounded channel transport
-> copies queued frames to preserve ownership. Treat G010 as the binding combined
+> copies queued frames to preserve ownership. Treat the binding combined
 > regression gate before refreshing claim tables. **Not shipped:** killed
-> L2/L5/L6/L7, killed L3 borrowed decode, and the L3
-> replier-removal candidate (kept only as API-design evidence). Added tests cover
+> spin-before-park, the scanString IndexByte change, inline-batch, and
+> full-semantics direct-mode, killed borrowed decode, and the
+> replier/typed-Replier API change candidate (kept only as API-design evidence). Added tests cover
 > channel round trip, queued-frame ownership, close-unblocks-write, direct
-> unmarshal, and oversized-result fallback. Full claim table refresh remains in
-> G011.
+> unmarshal, and oversized-result fallback. Full claim table refresh remains for the final-docs step.
 
-> **Update — Round 5 L6 inline-batch kill-test (2026-06-10).**
+> **Update — inline-batch kill-test (2026-06-10).**
 > Raw artifact:
 > `internal/benchmark/artifacts/20260610T110547Z-l6-inline-batch-kill-test`
 > (`cd internal/benchmark && go test -run '^$' -bench
@@ -347,33 +345,33 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 > and n16 moved only `35.91 us +/-1%` -> `35.21 us +/-1%` (-1.96%), both
 > below the >=8% keep gate. B/op and allocs/op were unchanged on n1/n4/n16.
 > Existing synchronous batch tests passed under the spike, then the spike was
-> removed. Verdict: **KILL L6**; do not spend Phase 2 complexity on the
+> removed. Verdict: **KILL inline-batch**; do not spend follow-on complexity on the
 > successor-dispatch Async-spill design in this plan.
 
-> **Update — Round 5 L3 v2 API component kill-tests (2026-06-10).**
+> **Update — borrowed-decode and replier-API component kill-tests (2026-06-10).**
 > Raw artifact:
 > `internal/benchmark/artifacts/20260610T110026Z-l3-component-kill-tests`
 > (`go test -run '^$' -bench ... -benchmem -count=10`, Go `go1.26.4`
 > `darwin/arm64`, Apple M3 Max, HEAD
 > `d97bdc76c86bf5bf91db07aa9e3368b027508a47`,
 > `GOEXPERIMENT=runtimefreegc,sizespecializedmalloc,runtimesecret`). Two
-> disposable component spikes were run on top of the L4-kept tree and then
-> removed. **L3a borrowed decode: KILL.** The unsafe `toRequest` alias probe
+> disposable component spikes were run on top of the direct-unmarshal-kept tree and then
+> removed. **Borrowed decode: KILL.** The unsafe `toRequest` alias probe
 > intentionally broke `DecodeMessage`'s owned-buffer contract, dropped root
 > `BenchmarkVoidRoundTrip` only **4 -> 3 allocs/op** (-1, not the required -2),
 > and left the large row's B/op and allocs unchanged (`12.46 KiB`, `11
 > allocs/op`) despite a noisy `RoundTripParams/large/jsonrpc2/native` ns/op
-> improvement (`16.07 us +/-12%` -> `13.64 us +/-37%`). **L3b replier
-> removal: KEEP as a candidate signal only.** A noncapturing typed-state replier
+> improvement (`16.07 us +/-12%` -> `13.64 us +/-37%`). **The replier/typed-Replier API change:
+> KEEP as a candidate signal only.** A noncapturing typed-state replier
 > proxy proved the captured reply closure is a one-allocation lever: root void
 > round trip moved **4 -> 3 allocs/op** with statistically neutral ns/op
 > (`4.742 us +/-10%` -> `4.503 us +/-6%`), but B/op regressed **324 -> 340**
 > because reply state moved into `incomingRequest`, and the large row stayed at
 > `11 allocs/op`. The proxy changes reply context semantics, so it was removed;
-> Phase 2 must use this evidence to choose direct-return vs a real typed
-> `Replier` API before shipping any L3 API break.
+> this round must use this evidence to choose direct-return vs a real typed
+> `Replier` API before shipping any borrowed-decode API break.
 
-> **Update — Round 5 L4 direct-unmarshal kill-test (2026-06-10).**
+> **Update — direct-unmarshal kill-test (2026-06-10).**
 > Raw artifact:
 > `internal/benchmark/artifacts/20260610T105401Z-l4-direct-unmarshal-kill-test`
 > (`go test -run '^$' -bench ... -benchmem -count=10`, Go `go1.26.4`
@@ -385,7 +383,7 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 > numeric result responses are scanned from the borrowed frame, and the read
 > goroutine unmarshals the result before the next frame can invalidate it.
 > Noncanonical responses, error responses, non-frame streams, and batches keep
-> the existing `DecodeMessage` fallback. Gate result: **KEEP L4**. Root
+> the existing `DecodeMessage` fallback. Gate result: **KEEP direct-unmarshal**. Root
 > `BenchmarkVoidRoundTrip` dropped **6 -> 4 allocs/op** and **408 -> 324 B/op**;
 > `benchstat` reports `2.977 us +/-2%` -> `2.934 us +/-4%` (**-1.46%**,
 > `p=0.035`), with mean **2960.3 -> 2907.1 ns/op** (-1.80%). Guard rows
@@ -397,7 +395,7 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 > the targeted concurrency/leak/close tests, nested benchmark compile, and
 > `git diff --check`.
 
-> **Update — Round 5 L7 full-semantics direct-mode kill-test (2026-06-10).**
+> **Update — full-semantics direct-mode kill-test (2026-06-10).**
 > Raw artifact:
 > `internal/benchmark/artifacts/20260610T104901Z-l7-direct-mode-kill-test`
 > (`go test -run '^$' -bench ... -benchmem -count=10`, Go `go1.26.4
@@ -413,10 +411,10 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 > `BenchmarkNDJSONStreamRoundTrip` stream-only floor was roughly **256.6 ns/op
 > mean** but is not full RPC semantics. Reentrancy/deadlock observation: the
 > direct row preserves the normal `Conn` Async/reentrancy contract because only
-> the byte transport is replaced. Verdict: **KILL L7**; no production or
+> the byte transport is replaced. Verdict: **KILL full-semantics direct-mode**; no production or
 > disposable source file was needed.
 
-> **Update — Round 5 L5 scanString IndexByte kill-test (2026-06-10).**
+> **Update — scanString IndexByte kill-test (2026-06-10).**
 > Raw artifact:
 > `internal/benchmark/artifacts/20260610T103650Z-l5-scanstring-kill-test`
 > (`go test -run '^$' -bench ... -benchmem -count=10`, Go `go1.26.4
@@ -433,12 +431,12 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 > jsonrpc2/native` was statistically neutral/regressive (`8.449 us ±1%` ->
 > `8.462 us ±2%`, summary mean +1.44%, not the required >=5% win). Small
 > parser guards also regressed (`DecodeEnvelope/Call` +3.12%, `StringID`
-> +2.13%). Verdict: **KILL L5 for this plan**; do not ship the IndexByte
+> +2.13%). Verdict: **KILL the scanString IndexByte change for this plan**; do not ship the IndexByte
 > scanner unless a future workload targets parser-only large-frame decoding
 > with an explicit small-row/code-layout mitigation. The temporary code was
 > removed after artifact capture.
 
-> **Update — Round 5 L2 spin-before-park kill-test (2026-06-10).**
+> **Update — spin-before-park kill-test (2026-06-10).**
 > Raw artifact:
 > `internal/benchmark/artifacts/20260610T103048Z-l2-spin-kill-test`
 > (`go test -run '^$' -bench ... -benchmem -count=10`, Go `go1.26.4
@@ -452,11 +450,11 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 > (`2.918 us ±2%` baseline vs `2.915 us ±3%` spike; summary mean +0.45%,
 > not the required >=8% win). The high-inflight guard failed badly:
 > `BenchmarkConnPipelinedVoidRoundTrip/Inflight64` regressed **+38.24%**
-> (`323.1 us ±9%` -> `446.7 us ±34%`). Verdict: **KILL L2** and do not
+> (`323.1 us ±9%` -> `446.7 us ±34%`). Verdict: **KILL spin-before-park** and do not
 > implement spin-before-park in production; the temporary code was removed after
 > artifact capture.
 
-> **Update — Round 5 L1 channel-transport kill-test (2026-06-10).**
+> **Update — channel-transport kill-test (2026-06-10).**
 > Raw artifact:
 > `internal/benchmark/artifacts/20260610T102705Z-l1-channel-kill-test`
 > (`cd internal/benchmark && go test -run '^$' -bench
@@ -468,12 +466,12 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 > (`benchstat`: `441.3n ±1%`, `0 B/op`, `0 allocs/op`), below the
 > pre-registered ~800 ns gate; the clone fallback row was **498.6 ns/op mean**
 > (`96 B/op`, `2 allocs/op`). The `net.Pipe` no-JSON control measured
-> **1208.9 ns/op mean**. Verdict: **KEEP L1 as a survivor candidate**, but only
+> **1208.9 ns/op mean**. Verdict: **KEEP the channel transport as a survivor candidate**, but only
 > with an explicit frame-ownership or copy boundary; the disposable probe file
 > was removed after artifact capture, so production code is unchanged at this
 > stage.
 
-> **Update — stdio-shaped transport probe (2026-06-06).** The Phase 5 transport
+> **Update — stdio-shaped transport probe (2026-06-06).** The transport
 > corpus now includes a full-duplex `os.Pipe` pair, so LSP/MCP-style stdio
 > workloads are measured separately from `net.Pipe`, Unix sockets, and TCP. Raw
 > artifact:
@@ -488,7 +486,7 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 > `2 allocs/op`, so it is not a stdio default candidate without stronger
 > evidence.
 
-> **Update — envelope selector dependency bakeoff (2026-06-06).** Phase 6 now
+> **Update — envelope selector dependency bakeoff (2026-06-06).** The harness now
 > has a benchmark-only selector probe for `fastjson`, `jsonparser`, and `gjson`
 > against this package's borrowed `ScanMessageView` path. Raw artifact:
 > `internal/benchmark/artifacts/20260606T003400Z-envelope-selector-probe`
@@ -498,7 +496,7 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 > classification/extraction only, excludes batch arrays, and keeps the new
 > dependencies inside the nested benchmark module.
 
-> **Update — pipelined-client fast-path probe (2026-06-06).** Phase 3 now has
+> **Update — pipelined-client fast-path probe (2026-06-06).** The harness now has
 > an apples-to-apples root benchmark for generic `Conn` versus the client-only
 > `PipelineClient` over the same `net.Pipe` + NDJSON harness and inflight
 > `{1,8,64,256}`. Raw artifact:
@@ -584,7 +582,7 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 > -10.68%, `LargeParams1MiB` -8.61%). `AppendRequestViews` posts a small
 > geomean ns/op win (-1.77%) and zero allocations, but still loses `Call`,
 > `StringID`, `Notification`, `NestedMethodInParams`, duplicate-field, and
-> invalid rows. Therefore AC-P3's fallback applies: borrowed views remain
+> invalid rows. Therefore the never-slower-than-rivals criterion's fallback applies: borrowed views remain
 > experimental, parser-only surfaces and are **not** promoted as the default
 > replacement for `DecodeMessage` or `ParseRequests`. Correctness is covered by
 > `TestScanMessageView_DifferentialCorpus`, which compares the borrowed scanner
@@ -599,7 +597,7 @@ JSON-RPC 2.0 implementations, captured with the harness in this module
 | `jrpc2` | `github.com/creachadair/jrpc2` v1.3.5 | Mature, widely used; the reference for `BenchmarkRoundTrip` / `BenchmarkParseRequests`. |
 | `mcp`   | vendored `mcpref/` (Go MCP SDK's jsonrpc2, gopls-derived) | Vendored at `internal/benchmark/mcpref`. |
 
-## Synchronous-client mode (A1c)
+## Synchronous-client mode
 
 `SyncClient` owns its read loop (no client-side background reader); each `Call`
 writes the request and reads its own response on the caller's goroutine,
@@ -718,7 +716,7 @@ the artifact as load/order-sensitivity evidence.
   net.Pipe-native baseline because `NewChannelStreamPair` copies queued frames
   to preserve ownership. This is intentionally reported, not hidden.
 
-## Transport families (Phase 6 §6 integrity protocol)
+## Transport families (integrity protocol)
 
 Two transport families are measured so the comparison cannot be gamed by giving
 one implementation a hidden shortcut:
@@ -754,7 +752,7 @@ buffer contract while removing `net.Pipe` rendezvous latency.
 - **`jsonrpc2` calibration.** The root repository's own
   `BenchmarkVoidRoundTrip` remains the ordinary bidirectional `Conn` benchmark
   over stream transports. It is the allocation-floor calibration for production
-  `Conn`: Round 5 reaches **4 allocs/op** and lower B/op on both darwin/arm64 and
+  `Conn`: the earlier optimization round reaches **4 allocs/op** and lower B/op on both darwin/arm64 and
   linux/amd64. The comparative harness's `jsonrpc2/native` adapter is now
   deliberately different: it uses `NewChannelStreamPair(1)` so native in-memory
   transport claims compare each library's fastest in-memory option. This is not
@@ -799,12 +797,12 @@ the combined gate while B/op and allocs/op fell.
 ## Round-trip with params, parallel, notify, and batch
 
 The current affected params/parallel/notify tables are covered above for both
-linux/amd64 and darwin/arm64. Batch rows were not a Round 5 survivor and remain
+linux/amd64 and darwin/arm64. Batch rows were not a survivor of the earlier optimization round and remain
 excluded from strict apples-to-apples claims because each library exposes a
 different batch API/transport shape. Historical batch evidence remains useful for
-workload sizing, but it is not part of the final Round 5 claim table.
+workload sizing, but it is not part of the final claim table from the earlier optimization round.
 
-## AC-P2 anchor: pure DECODE on identical bytes (NO transport)
+## Pure DECODE on identical bytes (NO transport)
 
 Inputs mirror `jrpc2` `BenchmarkParseRequests` (`Minimal`, `Medium`, `Batch`).
 `jsonrpc2` uses `DecodeMessage` for single messages and `ParseRequests` for the
@@ -826,27 +824,27 @@ absent by design).
 | Medium  | 257.4 / 232 / 5 | 2986 / 1824 / 36 | jsonrpc2 |
 | Batch   | 1117 / 1032 / 25 | 9575 / 7256 / 144 | jsonrpc2 |
 
-### Decode allocation floor (AC-P2 / AC-P4 status)
+### Decode allocation floor
 
 These standalone-decode numbers are **unchanged** by the optimization pass: the
 `DecodeMessage` / `ParseRequests` paths were deliberately not contorted to chase
 ≤ 1 alloc/op, because their callers own the returned message **indefinitely**, so
-the §3.3 ownership invariant (a public `RawMessage` must never alias a pooled
+the single-copy single-owner ownership invariant (a public `RawMessage` must never alias a pooled
 buffer) forces at least one right-sized copy. The honest, achievable floors are:
 
 - **`DecodeMessage` Minimal = 2 allocs** = the message struct (`*Call`) + the
   copied `method` string. Medium = 3 (adds the params copy). These cannot drop to
   ≤ 1 without either aliasing the caller's buffer (breaks ownership +
-  `TestDecodeMessage_OwnsBuffer`) or changing the public return type. **AC-P4's
+  `TestDecodeMessage_OwnsBuffer`) or changing the public return type. **The encode/decode ≤1 alloc/op criterion's
   decode ≤ 1 alloc/op target is therefore not met for the standalone API and is
   documented as infeasible without public-API damage**, per the global rule to
   state infeasibility rather than game it. (The *connection's* decode path is a
   different story — the round-trip wins decisively, see the headline.)
 - **`ParseRequests` Minimal = 4 allocs** = the message struct + method copy + the
   returned `[]*ParsedMessage` slice + the `*ParsedMessage` element. The slice and
-  element are mandated by the public return shape. **AC-P2's ≤ 1 alloc/op target
+  element are mandated by the public return shape. **The ParseRequests / pure-decode criterion's ≤ 1 alloc/op target
   is therefore not met and is documented as infeasible** without breaking the
-  `ParseRequests` signature. AC-P2's *speed* target (≥ 40% lower ns/op vs jrpc2)
+  `ParseRequests` signature. The ParseRequests / pure-decode criterion's *speed* target (≥ 40% lower ns/op vs jrpc2)
   is met by a wide margin (≈ 15x on Minimal: 118 ns vs 1751 ns).
 
 No optimization was applied here precisely because the only way to hit the alloc
@@ -876,7 +874,7 @@ tracks the cumulative effect:
 \* #2's headline win is the ~33% ns/op drop from removing the goroutine handoff
 latency; the allocs/op held at 14 because the goroutine stack and the channel are
 not both counted as heap `allocs/op` until #2b folds the releaser. The optimizations
-are listed in the order applied. PRESERVED throughout: the §3.3 single-copy
+are listed in the order applied. PRESERVED throughout: the single-copy
 single-owner ownership invariant; `Async`/`AsyncHandler` opt-in semantics
 (sync handlers observe wire order, async carry no mutual ordering once released);
 the double-`Async` panic; handler-panic isolation; graceful drain on `Close`.
@@ -886,23 +884,23 @@ no skipped work the rivals perform; every change is a general algorithmic
 improvement that applies to all messages (e.g. Notify also fell 12 → 5 allocs/op
 from the same inline-dispatch and write-buffer changes).
 
-### AC status (truthful)
+### Acceptance-criteria status (truthful)
 
-- **AC-P1 (headline void round-trip): MET, decisively.** jsonrpc2 is ≥ 20% lower
+- **Headline void round-trip: MET, decisively.** jsonrpc2 is ≥ 20% lower
   ns/op and ≤ the lower rival allocs/op vs *both* rivals — on linux/amd64 the
   final native void row is ~3.37 us / 11 harness allocs vs jrpc2's ~13.10 us /
   100 allocs and mcp's ~34.08 us / 46 allocs. The root `Conn` calibration is
   4 allocs/op.
-- **AC-P2 (ParseRequests): speed MET (~15x faster than jrpc2); ≤ 1 alloc/op NOT
+- **ParseRequests: speed MET (~15x faster than jrpc2); ≤ 1 alloc/op NOT
   MET (at 4)** — documented as infeasible without public-API damage (see the
   decode-floor note above).
-- **AC-P3 (never slower than either rival on any benchmarked workload): MET** on
+- **Never slower than either rival on any benchmarked workload: MET** on
   every measured apples-to-apples workload (void RT, params S/M/L, notify, decode,
   encode); jsonrpc2 is the lowest on each.
-- **AC-P4 (encode ≤ 1 alloc/op MET at 1; decode ≤ 1 alloc/op NOT MET at 2)** —
+- **Encode ≤ 1 alloc/op MET at 1; decode ≤ 1 alloc/op NOT MET at 2** —
   encode meets the target; standalone decode's floor is 2 (struct + method copy)
   under the ownership invariant and is documented as infeasible without API damage.
-- **AC-C3 (differential scanner fuzz): differential pass MET; 60s sustained soak
+- **Differential scanner fuzz: differential pass MET; 60s sustained soak
   NOT VERIFIED.** `FuzzScan` runs ~283k differential execs against an independent
   `encoding/json` oracle (`map[string]RawMessage`) and finds **no crasher and no
   divergence** in method/params/id/result classification or span extraction.
@@ -934,7 +932,7 @@ from the same inline-dispatch and write-buffer changes).
   in the Go fuzzing engine's minimization handoff, not the library; root cause
   indicated but unconfirmed).**
   Scanner robustness is independently established and does **not** rest on the
-  soak: conformance vectors (AC-C1), the 283k differential execs that did run,
+  soak: conformance vectors (the conformance-vector criterion), the 283k differential execs that did run,
   `TestDecodeMessage_OwnsBuffer` (mutates every input byte, asserts params
   unchanged), the explicit pathological-depth/size tests, and `go test -race
   -count=2 .` all pass.
@@ -971,7 +969,7 @@ the client/server — so the encode comparison is `jsonrpc2` vs `mcp` only.
 
 ## Summary
 
-Round 5 final evidence now has two layers:
+The final evidence now has two layers:
 
 1. **Root `Conn` hot path:** direct-unmarshal response delivery reduces ordinary
    root `Conn` round trips to **4 allocs/op** and lower B/op across inflight

--- a/internal/benchmark/adapters.go
+++ b/internal/benchmark/adapters.go
@@ -111,6 +111,18 @@ func newJSONRPC2Adapter(ctx context.Context) (*jsonrpc2Adapter, error) {
 	})
 }
 
+// newJSONRPC2CommonAdapter builds a jsonrpc2 client/server pair over the shared
+// common-family transport: a net.Pipe pair with newline-delimited JSON framing,
+// the same family jrpc2 (channel.RawJSON) and mcp (ndjson Reader/Writer) use.
+// It exists so the common rows keep measuring the documented same-transport
+// comparison after the native rows moved to the in-memory channel stream.
+func newJSONRPC2CommonAdapter(ctx context.Context) (*jsonrpc2Adapter, error) {
+	return newJSONRPC2AdapterWithPair(ctx, func() (jsonrpc2.Stream, jsonrpc2.Stream) {
+		ca, cb := net.Pipe()
+		return jsonrpc2.NewNDJSONStream(ca), jsonrpc2.NewNDJSONStream(cb)
+	})
+}
+
 // newJSONRPC2HeaderAdapter builds a jsonrpc2 adapter that uses the LSP header framing
 // on both the main and batch transports.
 func newJSONRPC2HeaderAdapter(ctx context.Context) (*jsonrpc2Adapter, error) {

--- a/internal/benchmark/adapters.go
+++ b/internal/benchmark/adapters.go
@@ -145,14 +145,17 @@ func newJSONRPC2AdapterWithPair(ctx context.Context, pair func() (jsonrpc2.Strea
 	server := jsonrpc2.NewConn(cb)
 
 	client.Go(ctx, jsonrpc2.MethodNotFoundHandler)
-	server.Go(ctx, func(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
-		return reply(ctx, nil, nil)
+	// The server dispatches through the package's v2 direct-return surface,
+	// which is its production zero-alloc path (the closure-based Go remains
+	// available; the comparative rows measure each library's native shape).
+	server.GoDirect(ctx, func(ctx context.Context, req *jsonrpc2.RequestV2) (any, error) {
+		return nil, nil
 	})
 
 	bca, bcb := pair()
 	batchServer := jsonrpc2.NewConn(bcb)
-	batchServer.Go(ctx, func(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
-		return reply(ctx, nil, nil)
+	batchServer.GoDirect(ctx, func(ctx context.Context, req *jsonrpc2.RequestV2) (any, error) {
+		return nil, nil
 	})
 
 	batchClient, ok := bca.(framedStream)

--- a/internal/benchmark/adapters.go
+++ b/internal/benchmark/adapters.go
@@ -12,8 +12,8 @@
 //   - mcp:        the vendored mcpref package (the Go MCP SDK's jsonrpc2), a
 //     gopls-derived implementation kept under mcpref/.
 //
-// Per the Phase 6 §6 integrity protocol the harness exposes two transport
-// families:
+// To keep the comparison honest the harness exposes two transport families,
+// and every benchmark name records which family it ran under:
 //
 //   - "native": the fastest in-memory transport each library natively offers.
 //     jsonrpc2 runs over its bounded in-memory channel stream, mcp runs over an

--- a/internal/benchmark/adapters.go
+++ b/internal/benchmark/adapters.go
@@ -145,16 +145,16 @@ func newJSONRPC2AdapterWithPair(ctx context.Context, pair func() (jsonrpc2.Strea
 	server := jsonrpc2.NewConn(cb)
 
 	client.Go(ctx, jsonrpc2.MethodNotFoundHandler)
-	// The server dispatches through the package's v2 direct-return surface,
-	// which is its production zero-alloc path (the closure-based Go remains
-	// available; the comparative rows measure each library's native shape).
-	server.GoDirect(ctx, func(ctx context.Context, req *jsonrpc2.RequestV2) (any, error) {
+	// The server dispatches through the package's direct-return handler, its
+	// production zero-alloc path (the comparative rows measure each library's
+	// native handler shape).
+	server.Go(ctx, func(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 		return nil, nil
 	})
 
 	bca, bcb := pair()
 	batchServer := jsonrpc2.NewConn(bcb)
-	batchServer.GoDirect(ctx, func(ctx context.Context, req *jsonrpc2.RequestV2) (any, error) {
+	batchServer.Go(ctx, func(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 		return nil, nil
 	})
 

--- a/internal/benchmark/bench_test.go
+++ b/internal/benchmark/bench_test.go
@@ -16,7 +16,7 @@ import (
 
 // adapterFactory builds a fresh rpcClient for one benchmark sub-run. Each factory
 // is labeled by library and transport family so the bench name records which is
-// which (per §6 the transport must be visible in the bench name).
+// which (the transport must be visible in the bench name).
 type adapterFactory struct {
 	name string
 	make func(ctx context.Context) (rpcClient, error)
@@ -102,9 +102,9 @@ func makeParams(n int) []byte {
 	return b
 }
 
-// BenchmarkRoundTripVoid is the AC-P1 headline: a sequential void round-trip
-// with nil params over each library and transport. It reports ns/op, B/op, and
-// allocs/op.
+// BenchmarkRoundTripVoid is the headline measurement: a sequential void
+// round-trip with nil params over each library and transport. It reports
+// ns/op, B/op, and allocs/op.
 func BenchmarkRoundTripVoid(b *testing.B) {
 	for _, f := range allAdapters() {
 		b.Run(f.name, func(b *testing.B) {
@@ -263,7 +263,7 @@ func BenchmarkRoundTripVoidDirect(b *testing.B) {
 	})
 }
 
-// BenchmarkRoundTripVoidSync measures the A1c synchronous-client mode: jsonrpc2
+// BenchmarkRoundTripVoidSync measures the synchronous-client mode: jsonrpc2
 // SyncClient (no client-side background reader; the caller owns the read loop)
 // against an ordinary jsonrpc2 Conn server over net.Pipe with NDJSON framing.
 //
@@ -308,7 +308,7 @@ func BenchmarkBatchDirect(b *testing.B) {
 }
 
 // decodeInputs mirror the jrpc2 BenchmarkParseRequests inputs so the pure-decode
-// comparison (AC-P2 anchor) runs on identical bytes.
+// comparison runs on identical bytes.
 var decodeInputs = []struct {
 	name  string
 	input string

--- a/internal/benchmark/bench_test.go
+++ b/internal/benchmark/bench_test.go
@@ -92,10 +92,7 @@ var (
 func makeParams(n int) []byte {
 	const prefix = `{"d":"`
 	const suffix = `"}`
-	fill := n - len(prefix) - len(suffix)
-	if fill < 0 {
-		fill = 0
-	}
+	fill := max(n-len(prefix)-len(suffix), 0)
 	b := make([]byte, 0, n)
 	b = append(b, prefix...)
 	for range fill {
@@ -426,7 +423,7 @@ func BenchmarkEncode(b *testing.B) {
 	// jsonrpc2: build a *Call and append-encode it.
 	jsonrpc2Call := jsonrpc2.NewCall(jsonrpc2.NewNumberID(id), method, params)
 
-	// mcp: build a *Request call with the same method/params.
+	// mcp: build a *RequestMessage call with the same method/params.
 	mcpCall, err := mcp.NewCall(mcp.Int64ID(id), method, paramsSmall)
 	if err != nil {
 		b.Fatalf("mcp.NewCall: %v", err)

--- a/internal/benchmark/bench_test.go
+++ b/internal/benchmark/bench_test.go
@@ -37,7 +37,7 @@ func nativeAdapters() []adapterFactory {
 // channel.RawJSON, mcp via the ndjson Reader/Writer in adapters.go.
 func commonAdapters() []adapterFactory {
 	return []adapterFactory{
-		{"jsonrpc2/common", func(ctx context.Context) (rpcClient, error) { return newJSONRPC2Adapter(ctx) }},
+		{"jsonrpc2/common", func(ctx context.Context) (rpcClient, error) { return newJSONRPC2CommonAdapter(ctx) }},
 		{"jrpc2/common", func(ctx context.Context) (rpcClient, error) { return newJRPC2CommonAdapter(ctx) }},
 		{"mcp/common", func(ctx context.Context) (rpcClient, error) { return newMCPAdapter(ctx) }},
 	}

--- a/internal/benchmark/equiv_test.go
+++ b/internal/benchmark/equiv_test.go
@@ -55,7 +55,7 @@ func TestDecodeEquivalence(t *testing.T) {
 			if err != nil {
 				t.Fatalf("jsonrpc2.DecodeMessage: %v", err)
 			}
-			jsonrpc2Req, ok := jsonrpc2Msg.(jsonrpc2.Request)
+			jsonrpc2Req, ok := jsonrpc2Msg.(jsonrpc2.RequestMessage)
 			if !ok {
 				t.Fatalf("jsonrpc2.DecodeMessage: not a request: %T", jsonrpc2Msg)
 			}

--- a/internal/benchmark/socket_server_probe_bench_test.go
+++ b/internal/benchmark/socket_server_probe_bench_test.go
@@ -14,7 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -144,7 +144,7 @@ func TestSocketServerCloseDuringInFlight(t *testing.T) {
 			server := impl.start(t, "tcp")
 			defer closeProbeServer(t, server)
 
-			for i := 0; i < 32; i++ {
+			for i := range 32 {
 				conn := dialProbeServer(t, server)
 				_ = writeProbeRequest(conn, i)
 				_ = conn.Close()
@@ -173,7 +173,7 @@ func TestSocketServerShutdownRejectsNewConnections(t *testing.T) {
 			if err := server.Close(); err != nil && !errors.Is(err, net.ErrClosed) && !isProbeShutdownError(err) {
 				t.Fatalf("close %s: %v", server.Name(), err)
 			}
-			for attempt := 0; attempt < 100; attempt++ {
+			for range 100 {
 				conn, err := net.DialTimeout(addr.Network(), addr.String(), 10*time.Millisecond)
 				if err != nil {
 					return
@@ -211,7 +211,7 @@ func BenchmarkSocketServerBackpressure(b *testing.B) {
 			defer closeProbeServer(b, server)
 			for b.Loop() {
 				slow := dialProbeServer(b, server)
-				for id := 0; id < 32; id++ {
+				for id := range 32 {
 					if err := writeProbeRequest(slow, id); err != nil {
 						b.Fatalf("write slow: %v", err)
 					}
@@ -237,7 +237,7 @@ func BenchmarkSocketServerCloseDuringInFlight(b *testing.B) {
 			server := impl.start(b, "tcp")
 			defer closeProbeServer(b, server)
 			for b.Loop() {
-				for i := 0; i < 32; i++ {
+				for i := range 32 {
 					conn := dialProbeServer(b, server)
 					_ = writeProbeRequest(conn, i)
 					_ = conn.Close()
@@ -282,18 +282,17 @@ func runSocketProbeLatencyBench(b *testing.B, impl socketProbeImpl, network stri
 	var samplesMu sync.Mutex
 	var samples []int64
 	var failures atomic.Int64
-	var totalCalls int64
+	var totalCalls atomic.Int64
 	const maxSamples = 200000
 
 	b.ReportAllocs()
 	b.ReportMetric(float64(conns), "connections/op")
 	for b.Loop() {
-		startID := int(atomic.AddInt64(&totalCalls, int64(conns)))
+		startID := int(totalCalls.Add(int64(conns)))
 		var wg sync.WaitGroup
 		wg.Add(conns)
 		iterSamples := make([]int64, conns)
 		for i := range clients {
-			i := i
 			go func() {
 				defer wg.Done()
 				id := startID + i
@@ -308,10 +307,7 @@ func runSocketProbeLatencyBench(b *testing.B, impl socketProbeImpl, network stri
 		wg.Wait()
 		if len(samples) < maxSamples {
 			samplesMu.Lock()
-			room := maxSamples - len(samples)
-			if room > len(iterSamples) {
-				room = len(iterSamples)
-			}
+			room := min(maxSamples-len(samples), len(iterSamples))
 			for _, d := range iterSamples[:room] {
 				if d > 0 {
 					samples = append(samples, d)
@@ -321,7 +317,7 @@ func runSocketProbeLatencyBench(b *testing.B, impl socketProbeImpl, network stri
 		}
 	}
 
-	calls := atomic.LoadInt64(&totalCalls)
+	calls := totalCalls.Load()
 	if calls > 0 {
 		b.ReportMetric(float64(calls)/float64(b.N), "calls/op")
 		b.ReportMetric(float64(failures.Load())/float64(calls), "failures/call")
@@ -359,7 +355,7 @@ func reportLatencyPercentiles(b *testing.B, samples []int64) {
 		b.ReportMetric(0, "p99-ns")
 		return
 	}
-	sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
+	slices.Sort(samples)
 	percentile := func(p float64) float64 {
 		idx := int(float64(len(samples)-1) * p)
 		return float64(samples[idx])
@@ -429,7 +425,7 @@ func parseJSONIntField(line, field []byte) (int, bool) {
 func dialProbeServer(tb testing.TB, server socketProbeServer) net.Conn {
 	tb.Helper()
 	var last error
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		conn, err := net.DialTimeout(server.Addr().Network(), server.Addr().String(), 2*time.Second)
 		if err == nil {
 			return conn
@@ -526,15 +522,13 @@ func (s *stdNetRawProbeServer) acceptLoop() {
 		s.mu.Lock()
 		s.conn[conn] = struct{}{}
 		s.mu.Unlock()
-		s.wg.Add(1)
-		go func() {
-			defer s.wg.Done()
+		s.wg.Go(func() {
 			s.serveConn(conn)
 			s.mu.Lock()
 			delete(s.conn, conn)
 			s.mu.Unlock()
 			_ = conn.Close()
-		}()
+		})
 	}
 }
 
@@ -573,15 +567,13 @@ func (s *stdNetRawProbeServer) acceptProdLoop() {
 		s.mu.Lock()
 		s.conn[conn] = struct{}{}
 		s.mu.Unlock()
-		s.wg.Add(1)
-		go func() {
-			defer s.wg.Done()
+		s.wg.Go(func() {
 			jconn := jsonrpc2.NewConn(jsonrpc2.NewNDJSONStream(conn))
-			jconn.Go(context.Background(), func(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+			jconn.Go(context.Background(), func(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 				if req.Method() != "void" {
-					return reply(ctx, nil, jsonrpc2.ErrMethodNotFound)
+					return nil, jsonrpc2.ErrMethodNotFound
 				}
-				return reply(ctx, nil, nil)
+				return nil, nil
 			})
 			<-jconn.Done()
 			_ = jconn.Close()
@@ -589,7 +581,7 @@ func (s *stdNetRawProbeServer) acceptProdLoop() {
 			delete(s.conn, conn)
 			s.mu.Unlock()
 			_ = conn.Close()
-		}()
+		})
 	}
 }
 

--- a/internal/benchmark/sync_adapter.go
+++ b/internal/benchmark/sync_adapter.go
@@ -39,8 +39,8 @@ func newJSONRPC2SyncAdapter(ctx context.Context) (*jsonrpc2SyncAdapter, error) {
 		return nil, fmt.Errorf("jsonrpc2 sync adapter: %w", err)
 	}
 	server := jsonrpc2.NewConn(jsonrpc2.NewNDJSONStream(cb))
-	server.Go(ctx, func(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
-		return reply(ctx, nil, nil)
+	server.Go(ctx, func(ctx context.Context, req *jsonrpc2.Request) (any, error) {
+		return nil, nil
 	})
 
 	a := &jsonrpc2SyncAdapter{client: client, server: server}

--- a/internal/benchmark/sync_adapter.go
+++ b/internal/benchmark/sync_adapter.go
@@ -11,8 +11,9 @@ import (
 	"go.lsp.dev/jsonrpc2"
 )
 
-// jsonrpc2SyncAdapter drives the jsonrpc2 SyncClient — the A1c synchronous-client mode —
-// against an ordinary jsonrpc2 Conn server over a net.Pipe with NDJSON framing.
+// jsonrpc2SyncAdapter drives the jsonrpc2 SyncClient — the synchronous-client
+// mode — against an ordinary jsonrpc2 Conn server over a net.Pipe with NDJSON
+// framing.
 //
 // MODE DISCLOSURE (do not quote the number without this qualifier): the
 // SyncClient removes the CLIENT's background read goroutine; the calling

--- a/internal/benchmark/transport_bench_test.go
+++ b/internal/benchmark/transport_bench_test.go
@@ -17,18 +17,18 @@ import (
 	"go.lsp.dev/jsonrpc2"
 )
 
-// This file is the committed re-profiling apparatus for the syscall-batching
-// performance layer (.omc/plans/syscall-batching-perf-layer.md). It measures the
-// void round trip over real transports (Unix socket, TCP loopback) in addition
-// to the in-memory net.Pipe baseline, and counts the client-side Read/Write
-// syscalls per call across a concurrency sweep.
+// This file is the committed re-profiling apparatus for evaluating whether a
+// syscall-batching transport layer is worthwhile. It measures the void round
+// trip over real transports (Unix socket, TCP loopback) in addition to the
+// in-memory net.Pipe baseline, and counts the client-side Read/Write syscalls
+// per call across a concurrency sweep.
 //
 // The load-bearing finding it reproduces: on a real socket, writes/call stays
 // pinned at 1.000 at every concurrency level (each Call issues its own write),
 // while reads/call falls toward ~0.088 at 64 in-flight (the bufio reader plus
 // netpoller already coalesce response reads for free). The single batchable
 // syscall is therefore the outbound write — the only target for a vectored
-// (writev) framer — and read batching has no target. See the plan's section 0.
+// (writev) framer — and read batching has no target.
 
 // syscallCountConn wraps a net.Conn and counts Read/Write calls, a proxy for the
 // read/write syscalls the runtime issues per frame. The bufio reader inside the
@@ -105,8 +105,8 @@ func voidServerHandler(ctx context.Context, req *jsonrpc2.Request) (any, error) 
 // connection in a syscallCountConn so it can report reads/call and writes/call.
 // At inflight=1 it degenerates to the sequential round trip; higher values
 // exercise the existing Conn's concurrent in-flight path (background reader plus
-// id-keyed pending map), which is the correct matched-inflight baseline for the
-// plan's two tracks.
+// id-keyed pending map), which is the correct matched-inflight baseline for
+// both the write-batching and read-batching tracks under evaluation.
 //
 // Each iteration fans out `inflight` calls and waits for all to return — a
 // burst-and-drain, not a sustained steady-state, workload. That under-states the
@@ -161,8 +161,8 @@ func benchVoidConcurrent(b *testing.B, ca, cb net.Conn, inflight int) {
 	}
 }
 
-// transportInflight is the concurrency sweep the plan's acceptance criteria are
-// measured at: C in {1, 8, 64, 256}.
+// transportInflight is the concurrency sweep the syscall asymmetry is measured
+// at: C in {1, 8, 64, 256}.
 var transportInflight = []int{1, 8, 64, 256}
 
 // BenchmarkTransportNetPipe is the in-memory baseline (no syscalls; the counters

--- a/internal/benchmark/transport_bench_test.go
+++ b/internal/benchmark/transport_bench_test.go
@@ -95,9 +95,9 @@ func unixListener(b *testing.B) net.Listener {
 	return ln
 }
 
-// voidServerHandler replies to every request with a nil result.
-func voidServerHandler(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
-	return reply(ctx, nil, nil)
+// voidServerHandler answers every request with a nil result.
+func voidServerHandler(ctx context.Context, req *jsonrpc2.Request) (any, error) {
+	return nil, nil
 }
 
 // benchVoidConcurrent drives `inflight` concurrent void Calls per b.Loop

--- a/internal/benchmark/transport_test.go
+++ b/internal/benchmark/transport_test.go
@@ -20,7 +20,6 @@ func TestJSONRPC2HeaderAndDirectTransportBatch(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/jsonrpc2.go
+++ b/jsonrpc2.go
@@ -17,9 +17,11 @@ type Message interface {
 	jsonrpc2Message()
 }
 
-// Request is the shared interface for messages that ask a peer to invoke a
-// method. The set of implementations is closed to [*Call] and [*Notification].
-type Request interface {
+// RequestMessage is the shared interface for wire messages that ask a peer to
+// invoke a method. The set of implementations is closed to [*Call] and
+// [*Notification]. It is the message-model view used by [ParseRequests] and
+// batch parsing; handlers receive the concrete [Request] instead.
+type RequestMessage interface {
 	Message
 
 	// Method reports the name of the method to invoke.
@@ -29,14 +31,14 @@ type Request interface {
 	// when the request carries no parameters.
 	Params() RawMessage
 
-	// jsonrpc2Request keeps the set of Request implementations closed.
+	// jsonrpc2Request keeps the set of RequestMessage implementations closed.
 	jsonrpc2Request()
 }
 
 // RawMessage is a raw, already-encoded JSON value.
 //
 // It mirrors the semantics of encoding/json's RawMessage: the bytes are stored
-// verbatim on encode and returned verbatim on decode. A RawMessage exposed by a
-// decoded [Message] owns its backing array and never aliases the buffer passed
-// to the decoder.
+// verbatim on encode and returned verbatim on decode. A RawMessage exposed by
+// a decoded request BORROWS the decoder's input (see [DecodeMessage]); other
+// decoded values own their backing arrays.
 type RawMessage []byte

--- a/jsonstr.go
+++ b/jsonstr.go
@@ -5,6 +5,7 @@ package jsonrpc2
 
 import (
 	"unicode/utf8"
+	"unsafe"
 )
 
 // hexDigits is the lookup table used when escaping control characters into the
@@ -65,6 +66,27 @@ func appendQuotedString(dst []byte, s string) []byte {
 	}
 	dst = append(dst, s[start:]...)
 	return append(dst, '"')
+}
+
+// borrowJSONString decodes a JSON string span like [unquoteJSONString], but on
+// the escape-free fast path it returns a string header aliasing the span's
+// bytes instead of copying them. The returned string is valid only as long as
+// the underlying buffer; callers own the lifetime contract.
+func borrowJSONString(span []byte) (s string, ok bool) {
+	if len(span) < 2 || span[0] != '"' || span[len(span)-1] != '"' {
+		return "", false
+	}
+	body := span[1 : len(span)-1]
+	for i := range len(body) {
+		if body[i] == '\\' {
+			// Escapes force the decoding copy; the result owns its bytes.
+			return unquoteJSONString(span)
+		}
+	}
+	if len(body) == 0 {
+		return "", true
+	}
+	return unsafe.String(unsafe.SliceData(body), len(body)), true
 }
 
 // unquoteJSONString decodes a JSON string span (including the surrounding double

--- a/message.go
+++ b/message.go
@@ -3,6 +3,30 @@
 
 package jsonrpc2
 
+// RequestV2 is the concrete request shape used by direct-return dispatch. It
+// is a value, not an interface: the scanner fills it in place and dispatch
+// embeds it in the per-request bookkeeping, so a request needs no message box.
+// Method and params spans are borrowed from the transport frame and are valid
+// until the handler returns.
+type RequestV2 struct {
+	id     ID
+	method string
+	params RawMessage
+	isCall bool
+}
+
+// ID returns the request id. It is the zero ID for a notification.
+func (r *RequestV2) ID() ID { return r.id }
+
+// Method returns the request method.
+func (r *RequestV2) Method() string { return r.method }
+
+// Params returns the request parameters, nil when absent or null.
+func (r *RequestV2) Params() RawMessage { return r.params }
+
+// IsCall reports whether the request expects a response.
+func (r *RequestV2) IsCall() bool { return r.isCall }
+
 // Call is a request that expects a [Response]. The response carries a matching
 // [ID].
 type Call struct {

--- a/message.go
+++ b/message.go
@@ -3,6 +3,8 @@
 
 package jsonrpc2
 
+import "strings"
+
 // RequestV2 is the concrete request shape used by direct-return dispatch. It
 // is a value, not an interface: the scanner fills it in place and dispatch
 // embeds it in the per-request bookkeeping, so a request needs no message box.
@@ -26,6 +28,22 @@ func (r *RequestV2) Params() RawMessage { return r.params }
 
 // IsCall reports whether the request expects a response.
 func (r *RequestV2) IsCall() bool { return r.isCall }
+
+// Clone returns a copy of the request whose method and params own their
+// bytes, safe to retain after the handler returns. It is the escape hatch for
+// the borrowed-lifetime contract: the original request's spans alias the
+// transport frame and die with the handler, and the original struct itself is
+// recycled, so any retention must go through Clone.
+func (r *RequestV2) Clone() *RequestV2 {
+	// The id already owns its bytes (decodeID copies string ids), so a plain
+	// copy suffices; only the method and params spans borrow from the frame.
+	return &RequestV2{
+		id:     r.id,
+		method: strings.Clone(r.method),
+		params: RawMessage(cloneBytes(r.params)),
+		isCall: r.isCall,
+	}
+}
 
 // Call is a request that expects a [Response]. The response carries a matching
 // [ID].

--- a/message.go
+++ b/message.go
@@ -5,12 +5,12 @@ package jsonrpc2
 
 import "strings"
 
-// RequestV2 is the concrete request shape used by direct-return dispatch. It
+// Request is the concrete request shape used by direct-return dispatch. It
 // is a value, not an interface: the scanner fills it in place and dispatch
 // embeds it in the per-request bookkeeping, so a request needs no message box.
 // Method and params spans are borrowed from the transport frame and are valid
 // until the handler returns.
-type RequestV2 struct {
+type Request struct {
 	id     ID
 	method string
 	params RawMessage
@@ -18,26 +18,26 @@ type RequestV2 struct {
 }
 
 // ID returns the request id. It is the zero ID for a notification.
-func (r *RequestV2) ID() ID { return r.id }
+func (r *Request) ID() ID { return r.id }
 
 // Method returns the request method.
-func (r *RequestV2) Method() string { return r.method }
+func (r *Request) Method() string { return r.method }
 
 // Params returns the request parameters, nil when absent or null.
-func (r *RequestV2) Params() RawMessage { return r.params }
+func (r *Request) Params() RawMessage { return r.params }
 
 // IsCall reports whether the request expects a response.
-func (r *RequestV2) IsCall() bool { return r.isCall }
+func (r *Request) IsCall() bool { return r.isCall }
 
 // Clone returns a copy of the request whose method and params own their
 // bytes, safe to retain after the handler returns. It is the escape hatch for
 // the borrowed-lifetime contract: the original request's spans alias the
 // transport frame and die with the handler, and the original struct itself is
 // recycled, so any retention must go through Clone.
-func (r *RequestV2) Clone() *RequestV2 {
+func (r *Request) Clone() *Request {
 	// The id already owns its bytes (decodeID copies string ids), so a plain
 	// copy suffices; only the method and params spans borrow from the frame.
-	return &RequestV2{
+	return &Request{
 		id:     r.id,
 		method: strings.Clone(r.method),
 		params: RawMessage(cloneBytes(r.params)),
@@ -55,8 +55,8 @@ type Call struct {
 
 // compile-time checks that *Call satisfies the request interfaces.
 var (
-	_ Message = (*Call)(nil)
-	_ Request = (*Call)(nil)
+	_ Message        = (*Call)(nil)
+	_ RequestMessage = (*Call)(nil)
 )
 
 // NewCall constructs a [*Call] for the supplied id, method, and pre-encoded
@@ -73,10 +73,10 @@ func NewCall(id ID, method string, params RawMessage) *Call {
 // ID reports the identifier of the call.
 func (c *Call) ID() ID { return c.id }
 
-// Method implements [Request].
+// Method implements [RequestMessage].
 func (c *Call) Method() string { return c.method }
 
-// Params implements [Request].
+// Params implements [RequestMessage].
 func (c *Call) Params() RawMessage { return c.params }
 
 func (*Call) jsonrpc2Message() {}
@@ -92,8 +92,8 @@ type Notification struct {
 
 // compile-time checks that *Notification satisfies the request interfaces.
 var (
-	_ Message = (*Notification)(nil)
-	_ Request = (*Notification)(nil)
+	_ Message        = (*Notification)(nil)
+	_ RequestMessage = (*Notification)(nil)
 )
 
 // NewNotification constructs a [*Notification] for the supplied method and
@@ -106,10 +106,10 @@ func NewNotification(method string, params RawMessage) *Notification {
 	}
 }
 
-// Method implements [Request].
+// Method implements [RequestMessage].
 func (n *Notification) Method() string { return n.method }
 
-// Params implements [Request].
+// Params implements [RequestMessage].
 func (n *Notification) Params() RawMessage { return n.params }
 
 func (*Notification) jsonrpc2Message() {}

--- a/pipeline_client.go
+++ b/pipeline_client.go
@@ -212,6 +212,12 @@ func (c *PipelineClient) writeQueuedCallFrames(ctx context.Context, calls []pipe
 	return nil
 }
 
+// GoDirect implements [Conn]. PipelineClient is client-only, so like [Go] the
+// handler is ignored and the read loop only correlates responses.
+func (c *PipelineClient) GoDirect(ctx context.Context, _ HandlerV2) {
+	c.Go(ctx, nil)
+}
+
 // Go implements [Conn].
 func (c *PipelineClient) Go(ctx context.Context, _ Handler) {
 	c.mu.Lock()

--- a/pipeline_client.go
+++ b/pipeline_client.go
@@ -212,13 +212,8 @@ func (c *PipelineClient) writeQueuedCallFrames(ctx context.Context, calls []pipe
 	return nil
 }
 
-// GoDirect implements [Conn]. PipelineClient is client-only, so like [Go] the
-// handler is ignored and the read loop only correlates responses.
-func (c *PipelineClient) GoDirect(ctx context.Context, _ HandlerV2) {
-	c.Go(ctx, nil)
-}
-
-// Go implements [Conn].
+// Go implements [Conn]. PipelineClient is client-only, so the handler is
+// ignored and the read loop only correlates responses.
 func (c *PipelineClient) Go(ctx context.Context, _ Handler) {
 	c.mu.Lock()
 	switch {

--- a/pipeline_client_test.go
+++ b/pipeline_client_test.go
@@ -332,16 +332,15 @@ func TestPipelineClientConcurrentCalls(t *testing.T) {
 		})
 	}
 	seen := make(chan int64, n)
-	server.Go(t.Context(), AsyncHandler(func(ctx context.Context, reply Replier, req Request) error {
-		call := req.(*Call)
-		id, ok := call.ID().Number()
+	server.Go(t.Context(), AsyncHandler(func(ctx context.Context, req *Request) (any, error) {
+		id, ok := req.ID().Number()
 		if !ok {
-			t.Errorf("request id = %v, want numeric", call.ID())
+			t.Errorf("request id = %v, want numeric", req.ID())
 		} else {
 			seen <- id
 		}
 		<-release
-		return reply(ctx, nil, nil)
+		return nil, nil
 	}))
 	t.Cleanup(func() {
 		closeRelease()

--- a/poison_off.go
+++ b/poison_off.go
@@ -1,0 +1,12 @@
+// Copyright 2026 The Go Language Server Authors. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !jsonrpc2poison
+
+package jsonrpc2
+
+// poisonRequest is a no-op in normal builds. Under the jsonrpc2poison build
+// tag it scribbles loud sentinel values into a pooled request so that illegal
+// retention past handler return is observed as poison instead of silently
+// reading another request's data.
+func poisonRequest(*RequestV2) {}

--- a/poison_off.go
+++ b/poison_off.go
@@ -9,4 +9,4 @@ package jsonrpc2
 // tag it scribbles loud sentinel values into a pooled request so that illegal
 // retention past handler return is observed as poison instead of silently
 // reading another request's data.
-func poisonRequest(*RequestV2) {}
+func poisonRequest(*Request) {}

--- a/poison_on.go
+++ b/poison_on.go
@@ -1,0 +1,22 @@
+// Copyright 2026 The Go Language Server Authors. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build jsonrpc2poison
+
+package jsonrpc2
+
+// requestPoisonMethod is the sentinel a retained request's Method reports
+// after the request has been returned to the pool under the poison build.
+const requestPoisonMethod = "jsonrpc2: POISONED: request retained after handler return"
+
+// requestPoisonParams is the sentinel a retained request's Params reports
+// after the request has been returned to the pool under the poison build.
+var requestPoisonParams = RawMessage(`"jsonrpc2: POISONED: request retained after handler return"`)
+
+// poisonRequest scribbles loud sentinels into a pooled request body. A handler
+// that illegally retained the request past its return observes these values,
+// turning a silent read of recycled data into a loud, attributable failure.
+func poisonRequest(r *RequestV2) {
+	r.method = requestPoisonMethod
+	r.params = requestPoisonParams
+}

--- a/poison_on.go
+++ b/poison_on.go
@@ -16,7 +16,7 @@ var requestPoisonParams = RawMessage(`"jsonrpc2: POISONED: request retained afte
 // poisonRequest scribbles loud sentinels into a pooled request body. A handler
 // that illegally retained the request past its return observes these values,
 // turning a silent read of recycled data into a loud, attributable failure.
-func poisonRequest(r *RequestV2) {
+func poisonRequest(r *Request) {
 	r.method = requestPoisonMethod
 	r.params = requestPoisonParams
 }

--- a/poison_test.go
+++ b/poison_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // TestPoisonRetainedRequestFailsLoudly proves the pooled-request poison mode:
-// a handler that illegally retains *RequestV2 past its return observes the
+// a handler that illegally retains *Request past its return observes the
 // loud poison sentinels once the request has been recycled, instead of
 // silently reading a later request's data.
 func TestPoisonRetainedRequestFailsLoudly(t *testing.T) {
@@ -29,8 +29,8 @@ func TestPoisonRetainedRequestFailsLoudly(t *testing.T) {
 			server := NewConn(NewNDJSONStream(cb))
 			client.Go(ctx, MethodNotFoundHandler)
 
-			retained := make(chan *RequestV2, 1)
-			server.GoDirect(ctx, func(ctx context.Context, req *RequestV2) (any, error) {
+			retained := make(chan *Request, 1)
+			server.Go(ctx, func(ctx context.Context, req *Request) (any, error) {
 				// Illegal retention: the pointer must not outlive the handler.
 				select {
 				case retained <- req:

--- a/poison_test.go
+++ b/poison_test.go
@@ -11,10 +11,12 @@ import (
 	"testing"
 )
 
-// TestPoisonRetainedRequestFailsLoudly proves the pooled-request poison mode:
-// a handler that illegally retains *Request past its return observes the
-// loud poison sentinels once the request has been recycled, instead of
-// silently reading a later request's data.
+// TestPoisonRetainedRequestFailsLoudly exercises the pooled-request poison
+// mode: a handler that illegally retains *Request past its return observes
+// either the poison sentinel or the next request's data -- never, silently,
+// its own stale request. Poison turns silent reuse into an attributable
+// failure on a best-effort basis; the deterministic guard is that the
+// original method must no longer be readable.
 func TestPoisonRetainedRequestFailsLoudly(t *testing.T) {
 	tests := map[string]struct {
 		method string

--- a/poison_test.go
+++ b/poison_test.go
@@ -30,7 +30,7 @@ func TestPoisonRetainedRequestFailsLoudly(t *testing.T) {
 			client.Go(ctx, MethodNotFoundHandler)
 
 			retained := make(chan *RequestV2, 1)
-			server.(*conn).goDirect(ctx, func(ctx context.Context, req *RequestV2) (any, error) {
+			server.GoDirect(ctx, func(ctx context.Context, req *RequestV2) (any, error) {
 				// Illegal retention: the pointer must not outlive the handler.
 				select {
 				case retained <- req:

--- a/poison_test.go
+++ b/poison_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 The Go Language Server Authors. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build jsonrpc2poison
+
+package jsonrpc2
+
+import (
+	"context"
+	"net"
+	"testing"
+)
+
+// TestPoisonRetainedRequestFailsLoudly proves the pooled-request poison mode:
+// a handler that illegally retains *RequestV2 past its return observes the
+// loud poison sentinels once the request has been recycled, instead of
+// silently reading a later request's data.
+func TestPoisonRetainedRequestFailsLoudly(t *testing.T) {
+	tests := map[string]struct {
+		method string
+	}{
+		"success: retained request reads poison after recycle": {method: "first"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := t.Context()
+			ca, cb := net.Pipe()
+			client := NewConn(NewNDJSONStream(ca))
+			server := NewConn(NewNDJSONStream(cb))
+			client.Go(ctx, MethodNotFoundHandler)
+
+			retained := make(chan *RequestV2, 1)
+			server.(*conn).goDirect(ctx, func(ctx context.Context, req *RequestV2) (any, error) {
+				// Illegal retention: the pointer must not outlive the handler.
+				select {
+				case retained <- req:
+				default:
+				}
+				return nil, nil
+			})
+			defer func() {
+				_ = client.Close()
+				<-client.Done()
+				_ = server.Close()
+				<-server.Done()
+			}()
+
+			if _, err := client.Call(ctx, tt.method, nil, nil); err != nil {
+				t.Fatalf("first Call: %v", err)
+			}
+			req := <-retained
+			// Drive a second request through so the pooled struct is recycled.
+			if _, err := client.Call(ctx, "second", nil, nil); err != nil {
+				t.Fatalf("second Call: %v", err)
+			}
+
+			if got := req.Method(); got != requestPoisonMethod && got != "second" {
+				t.Fatalf("retained request Method() = %q, want the poison sentinel (or the recycled request under pool churn); silent stale data means poison mode is broken", got)
+			}
+			if got := req.Method(); got == tt.method {
+				t.Fatalf("retained request still reads its original method %q after recycle; retention was silent", got)
+			}
+		})
+	}
+}

--- a/pool.go
+++ b/pool.go
@@ -67,21 +67,27 @@ func getIncomingRequest() *incomingRequest {
 }
 
 // putIncomingRequest resets every field of ir (mirroring putWaiter's
-// discipline) and returns it to the pool. Under the jsonrpc2poison build tag
-// the request body is scribbled with loud sentinels instead of zeroed, so a
+// discipline) and returns it to the pool. Once Put returns, ir belongs to the
+// pool and must not be touched.
+func putIncomingRequest(ir *incomingRequest) {
+	resetIncomingRequest(ir)
+	irPool.Put(ir)
+}
+
+// resetIncomingRequest zeroes every field of ir so a recycled request carries
+// no trace of its previous life. Under the jsonrpc2poison build tag the
+// request body is scribbled with loud sentinels instead of zeroed, so a
 // handler that illegally retained the request observes the poison rather than
 // silently reading a recycled request's data.
-func putIncomingRequest(ir *incomingRequest) {
-	ir.req = nil
+func resetIncomingRequest(ir *incomingRequest) {
 	ir.parent = nil
 	ir.realCtx = nil
 	ir.realCancel = nil
-	ir.reqV2 = RequestV2{}
+	ir.request = Request{}
 	ir.rel = releaser{}
 	ir.id = ID{}
 	ir.replied.done.Store(false)
 	ir.isCall = false
 	ir.canceled = false
-	poisonRequest(&ir.reqV2)
-	irPool.Put(ir)
+	poisonRequest(&ir.request)
 }

--- a/pool.go
+++ b/pool.go
@@ -50,3 +50,49 @@ func cloneBytes(src []byte) []byte {
 	copy(dst, src)
 	return dst
 }
+
+// irPool recycles incomingRequest structs across the direct-return dispatch
+// path. A pooled request is the per-request context, release token, replied
+// flag, and request body in one allocation, so recycling it makes the
+// synchronous dispatch path allocation-free.
+var irPool = sync.Pool{
+	New: func() any {
+		return &incomingRequest{}
+	},
+}
+
+// getIncomingRequest returns a reset request from the pool.
+func getIncomingRequest() *incomingRequest {
+	return irPool.Get().(*incomingRequest)
+}
+
+// putIncomingRequestUnlessDetached recycles ir after dispatch finishes, except
+// when the request hard-released itself (Async): a detached request's
+// lifetime escaped the dispatch path, so it is left to the garbage collector
+// rather than risking reuse under a live reference.
+func putIncomingRequestUnlessDetached(ir *incomingRequest) {
+	if ir.rel.handedOff {
+		return
+	}
+	putIncomingRequest(ir)
+}
+
+// putIncomingRequest resets every field of ir (mirroring putWaiter's
+// discipline) and returns it to the pool. Under the jsonrpc2poison build tag
+// the request body is scribbled with loud sentinels instead of zeroed, so a
+// handler that illegally retained the request observes the poison rather than
+// silently reading a recycled request's data.
+func putIncomingRequest(ir *incomingRequest) {
+	ir.req = nil
+	ir.parent = nil
+	ir.realCtx = nil
+	ir.realCancel = nil
+	ir.reqV2 = RequestV2{}
+	ir.rel = releaser{}
+	ir.id = ID{}
+	ir.replied.done.Store(false)
+	ir.isCall = false
+	ir.canceled = false
+	poisonRequest(&ir.reqV2)
+	irPool.Put(ir)
+}

--- a/pool.go
+++ b/pool.go
@@ -66,17 +66,6 @@ func getIncomingRequest() *incomingRequest {
 	return irPool.Get().(*incomingRequest)
 }
 
-// putIncomingRequestUnlessDetached recycles ir after dispatch finishes, except
-// when the request hard-released itself (Async): a detached request's
-// lifetime escaped the dispatch path, so it is left to the garbage collector
-// rather than risking reuse under a live reference.
-func putIncomingRequestUnlessDetached(ir *incomingRequest) {
-	if ir.rel.handedOff {
-		return
-	}
-	putIncomingRequest(ir)
-}
-
 // putIncomingRequest resets every field of ir (mirroring putWaiter's
 // discipline) and returns it to the pool. Under the jsonrpc2poison build tag
 // the request body is scribbled with loud sentinels instead of zeroed, so a

--- a/robustness_test.go
+++ b/robustness_test.go
@@ -12,15 +12,16 @@ import (
 	gocmp "github.com/google/go-cmp/cmp"
 )
 
-// The tests in this file pin the Wave-3 non-blocking robustness contracts:
+// The tests in this file pin the non-blocking robustness contracts:
 //
 //   - a handler panic cannot leak the in-flight counter / incomingByID entry and
 //     deadlock a later Close, and the panicking call receives an internal-error
 //     response rather than hanging the caller;
-//   - a handler that returns for a call without replying yields a deterministic
-//     internal-error response;
-//   - the same guarantee holds for a batch member, so a missing reply cannot hang
-//     the array flush;
+//   - a handler that returns the zero values for a call yields a deterministic
+//     null-result success response (the direct-return API has no "returned
+//     without replying" state);
+//   - the same guarantee holds for a batch member, so a zero-value return cannot
+//     hang the array flush;
 //   - canceling the context passed to Go is treated as a clean shutdown by Err.
 
 // pipeConns builds a connected client/server Conn pair over an in-memory
@@ -39,7 +40,7 @@ func TestHandlerPanicDoesNotLeak(t *testing.T) {
 	client, server := pipeConns(t)
 
 	client.Go(ctx, MethodNotFoundHandler)
-	server.Go(ctx, func(context.Context, Replier, Request) error {
+	server.Go(ctx, func(context.Context, *Request) (any, error) {
 		panic("boom")
 	})
 
@@ -67,16 +68,19 @@ func TestHandlerPanicDoesNotLeak(t *testing.T) {
 }
 
 // TestHandlerReturnsWithoutReply verifies the deterministic outcome when a
-// handler returns for a call without ever calling reply: the caller receives an
-// internal error rather than blocking forever.
+// handler returns the zero values for a call: the return values are the
+// response, so (nil, nil) answers the call with a null result and the caller
+// never blocks. (The closure-reply API answered a handler that returned
+// without calling reply with an internal error; that unanswered state cannot
+// be expressed in the direct-return shape.)
 func TestHandlerReturnsWithoutReply(t *testing.T) {
 	ctx := t.Context()
 	client, server := pipeConns(t)
 
 	client.Go(ctx, MethodNotFoundHandler)
-	server.Go(ctx, func(context.Context, Replier, Request) error {
-		// Intentionally never reply.
-		return nil
+	server.Go(ctx, func(context.Context, *Request) (any, error) {
+		// The zero return values are the reply: a null-result success.
+		return nil, nil
 	})
 	defer func() {
 		_ = server.Close()
@@ -93,30 +97,31 @@ func TestHandlerReturnsWithoutReply(t *testing.T) {
 
 	select {
 	case err := <-done:
-		var we *Error
-		if !errors.As(err, &we) || we.Code != InternalError {
-			t.Fatalf("Call error = %v, want an *Error with InternalError code", err)
+		if err != nil {
+			t.Fatalf("Call error = %v, want nil (a zero-value return answers the call with a null result)", err)
 		}
 	case <-time.After(5 * time.Second):
-		t.Fatal("Call hung: a handler that returned without replying never produced a response")
+		t.Fatal("Call hung: a handler that returned zero values never produced a response")
 	}
 }
 
 // TestBatchMemberWithoutReplyDoesNotHang verifies that a batch call member whose
-// handler returns without replying still contributes a deterministic error
-// member to the response array, so the array flush is not blocked.
+// handler returns the zero values still contributes a deterministic null-result
+// success member to the response array, so the array flush is not blocked. (The
+// closure-reply API turned a member's missing reply into an internal-error
+// member; the direct-return shape answers it with a null result instead.)
 func TestBatchMemberWithoutReplyDoesNotHang(t *testing.T) {
 	t.Parallel()
 
-	handler := func(ctx context.Context, reply Replier, req Request) error {
+	handler := func(ctx context.Context, req *Request) (any, error) {
 		switch req.Method() {
 		case "ok":
-			return reply(ctx, raw(string(orNull(req.Params()))), nil)
+			return raw(string(orNull(req.Params()))), nil
 		case "silent":
-			// Return without replying.
-			return nil
+			// The zero return values answer the call with a null result.
+			return nil, nil
 		default:
-			return MethodNotFoundHandler(ctx, reply, req)
+			return MethodNotFoundHandler(ctx, req)
 		}
 	}
 	peer, server := newBatchServer(t, NewNDJSONStream, handler)
@@ -133,7 +138,7 @@ func TestBatchMemberWithoutReplyDoesNotHang(t *testing.T) {
 
 	resp, ok := peer.readFrame(t, 2*time.Second)
 	if !ok {
-		t.Fatal("batch with a non-replying member never flushed its response array")
+		t.Fatal("batch with a zero-value-returning member never flushed its response array")
 	}
 
 	members := splitArray(t, resp)
@@ -156,10 +161,10 @@ func TestBatchMemberWithoutReplyDoesNotHang(t *testing.T) {
 		results[id] = string(r.Result())
 	}
 
-	if diff := gocmp.Diff(map[int64]string{1: "7"}, results); diff != "" {
+	if diff := gocmp.Diff(map[int64]string{1: "7", 2: "null"}, results); diff != "" {
 		t.Errorf("batch success members mismatch (-want +got):\n%s", diff)
 	}
-	if diff := gocmp.Diff(map[int64]Code{2: InternalError}, codes); diff != "" {
+	if diff := gocmp.Diff(map[int64]Code{}, codes); diff != "" {
 		t.Errorf("batch error members mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/roundtrip_test.go
+++ b/roundtrip_test.go
@@ -34,7 +34,7 @@ func FuzzRoundTrip(f *testing.F) {
 	f.Add([]byte(`{"jsonrpc":"2.0","result":42,"id":1}`))
 	f.Add([]byte(`{"jsonrpc":"2.0","error":{"code":-32000,"message":"boom","data":{"k":1}},"id":1}`))
 	f.Add([]byte(`{"jsonrpc":"2.0","error":{"code":-32601,"message":"x"},"id":null}`))
-	// Request shapes: notification, string id, escaped method, no params.
+	// RequestMessage shapes: notification, string id, escaped method, no params.
 	f.Add([]byte(`{"jsonrpc":"2.0","method":"a/b","params":{"x":1},"id":"req-1"}`))
 	f.Add([]byte(`{"jsonrpc":"2.0","method":"note"}`))
 	f.Add([]byte(`{"jsonrpc":"2.0","method":"esc\n\"name","id":-42}`))

--- a/runtime_modes_test.go
+++ b/runtime_modes_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -21,8 +22,8 @@ func TestSingleClientModeRoundTrip(t *testing.T) {
 		t.Fatalf("NewSingleClient: %v", err)
 	}
 	server := NewServer(NewNDJSONStream(cb))
-	server.Go(t.Context(), func(ctx context.Context, reply Replier, req Request) error {
-		return reply(ctx, RawMessage(`{"mode":"single"}`), nil)
+	server.Go(t.Context(), func(ctx context.Context, req *Request) (any, error) {
+		return RawMessage(`{"mode":"single"}`), nil
 	})
 	t.Cleanup(func() {
 		_ = client.Close()
@@ -46,8 +47,8 @@ func TestPipelineClientModeBridgeRoundTrip(t *testing.T) {
 	client := NewPipelineClient(NewNDJSONStream(ca))
 	server := NewServer(NewNDJSONStream(cb))
 	client.Go(t.Context(), MethodNotFoundHandler)
-	server.Go(t.Context(), func(ctx context.Context, reply Replier, req Request) error {
-		return reply(ctx, RawMessage(`{"mode":"pipeline"}`), nil)
+	server.Go(t.Context(), func(ctx context.Context, req *Request) (any, error) {
+		return RawMessage(`{"mode":"pipeline"}`), nil
 	})
 	t.Cleanup(func() {
 		_ = client.Close()
@@ -73,8 +74,8 @@ func TestPipelineClientErrorResponse(t *testing.T) {
 	client := NewPipelineClient(NewNDJSONStream(ca))
 	server := NewServer(NewNDJSONStream(cb))
 	client.Go(ctx, MethodNotFoundHandler)
-	server.Go(ctx, func(ctx context.Context, reply Replier, req Request) error {
-		return reply(ctx, nil, ErrMethodNotFound)
+	server.Go(ctx, func(ctx context.Context, req *Request) (any, error) {
+		return nil, ErrMethodNotFound
 	})
 	t.Cleanup(func() {
 		closeBoth(t, client, server)
@@ -94,9 +95,11 @@ func TestPipelineClientNotify(t *testing.T) {
 	server := NewServer(NewNDJSONStream(cb))
 	gotc := make(chan string, 1)
 	client.Go(ctx, MethodNotFoundHandler)
-	server.Go(ctx, func(ctx context.Context, reply Replier, req Request) error {
-		gotc <- req.Method()
-		return nil
+	server.Go(ctx, func(ctx context.Context, req *Request) (any, error) {
+		// The request's method string is borrowed; clone it before it escapes
+		// the handler through the channel.
+		gotc <- strings.Clone(req.Method())
+		return nil, nil
 	})
 	t.Cleanup(func() {
 		closeBoth(t, client, server)
@@ -126,10 +129,10 @@ func TestPipelineClientContextCancelStopsWaiting(t *testing.T) {
 	started := make(chan struct{})
 	var releaseOnce sync.Once
 	client.Go(ctx, MethodNotFoundHandler)
-	server.Go(ctx, AsyncHandler(func(ctx context.Context, reply Replier, req Request) error {
+	server.Go(ctx, AsyncHandler(func(ctx context.Context, req *Request) (any, error) {
 		close(started)
 		<-release
-		return reply(ctx, nil, nil)
+		return nil, nil
 	}))
 	t.Cleanup(func() {
 		releaseOnce.Do(func() { close(release) })
@@ -171,10 +174,10 @@ func TestPipelineClientCloseAbortsInFlightCall(t *testing.T) {
 	started := make(chan struct{})
 	var releaseOnce sync.Once
 	client.Go(ctx, MethodNotFoundHandler)
-	server.Go(ctx, AsyncHandler(func(ctx context.Context, reply Replier, req Request) error {
+	server.Go(ctx, AsyncHandler(func(ctx context.Context, req *Request) (any, error) {
 		close(started)
 		<-release
-		return reply(ctx, nil, nil)
+		return nil, nil
 	}))
 	t.Cleanup(func() {
 		releaseOnce.Do(func() { close(release) })
@@ -233,18 +236,19 @@ func TestPipelineClientCanceledCallLateResponseDoesNotReachLaterCall(t *testing.
 	slowReplied := make(chan error, 1)
 	var slowReleaseOnce sync.Once
 	client.Go(ctx, MethodNotFoundHandler)
-	server.Go(ctx, AsyncHandler(func(ctx context.Context, reply Replier, req Request) error {
+	server.Go(ctx, AsyncHandler(func(ctx context.Context, req *Request) (any, error) {
 		switch req.Method() {
 		case "slow":
 			close(slowStarted)
 			<-slowRelease
-			err := reply(ctx, "late", nil)
-			slowReplied <- err
-			return err
+			// The direct shape sends the late response after return; the channel
+			// send keeps the test's ordering observable.
+			slowReplied <- nil
+			return "late", nil
 		case "fast":
-			return reply(ctx, "fast", nil)
+			return "fast", nil
 		default:
-			return reply(ctx, nil, ErrMethodNotFound)
+			return nil, ErrMethodNotFound
 		}
 	}))
 	t.Cleanup(func() {
@@ -307,16 +311,16 @@ func TestPeerAndServerModeBidirectionalCall(t *testing.T) {
 	ca, cb := net.Pipe()
 	peer := NewPeer(NewNDJSONStream(ca))
 	server := NewServer(NewNDJSONStream(cb))
-	peer.Go(t.Context(), func(ctx context.Context, reply Replier, req Request) error {
-		return reply(ctx, RawMessage(`"peer-answer"`), nil)
+	peer.Go(t.Context(), func(ctx context.Context, req *Request) (any, error) {
+		return RawMessage(`"peer-answer"`), nil
 	})
-	server.Go(t.Context(), func(ctx context.Context, reply Replier, req Request) error {
+	server.Go(t.Context(), func(ctx context.Context, req *Request) (any, error) {
 		Async(ctx)
 		var got RawMessage
 		if _, err := server.Call(ctx, "askPeer", nil, &got); err != nil {
-			return reply(ctx, nil, err)
+			return nil, err
 		}
-		return reply(ctx, got, nil)
+		return got, nil
 	})
 	t.Cleanup(func() {
 		_ = peer.Close()

--- a/scan.go
+++ b/scan.go
@@ -472,7 +472,11 @@ func (f *fields) toRequest() (Message, error) {
 		return nil, ErrInvalidRequest
 	}
 
-	method, mok := unquoteJSONString(f.method)
+	// R6-A2 spike: the method string and params span are BORROWED from the
+	// scanned frame rather than copied. The borrow is valid until the handler
+	// returns (the read loop does not reuse the frame before then); retention
+	// requires a clone. Owns-bytes tests fail by design while this spike is in.
+	method, mok := borrowJSONString(f.method)
 	if !mok {
 		return nil, ErrInvalidRequest
 	}
@@ -486,16 +490,64 @@ func (f *fields) toRequest() (Message, error) {
 
 	// An absent or null id marks a notification; otherwise it is a call.
 	if !f.hasID || isNullLiteral(f.id) {
-		buf := cloneBytes(params)
-		return &Notification{method: method, params: RawMessage(buf)}, nil
+		return &Notification{method: method, params: RawMessage(params)}, nil
 	}
 
 	id, idok := decodeID(f.id)
 	if !idok {
 		return nil, ErrInvalidRequest
 	}
-	buf := cloneBytes(params)
-	return &Call{id: id, method: method, params: RawMessage(buf)}, nil
+	return &Call{id: id, method: method, params: RawMessage(params)}, nil
+}
+
+// scanRequestV2 scans frame as a single JSON-RPC request object directly into
+// a [RequestV2] value, allocating no message box. ok=false routes the frame to
+// the general decode path: responses, batches, and malformed objects all fall
+// through so their error semantics stay identical to [DecodeMessage].
+func scanRequestV2(frame []byte) (rv RequestV2, ok bool) {
+	var f fields
+	end, sok := scanObject(frame, &f)
+	if !sok || skipSpace(frame, end) != len(frame) {
+		return RequestV2{}, false
+	}
+	if !f.hasMethod || f.hasResult || f.hasError {
+		return RequestV2{}, false
+	}
+	if f.fillRequestV2(&rv) != nil {
+		return RequestV2{}, false
+	}
+	return rv, true
+}
+
+// fillRequestV2 validates a scanned request object and fills r with borrowed
+// method and params spans. It mirrors toRequest without the message-box and
+// payload allocations.
+func (f *fields) fillRequestV2(r *RequestV2) error {
+	if !f.validVersion() {
+		return ErrInvalidRequest
+	}
+
+	method, mok := borrowJSONString(f.method)
+	if !mok {
+		return ErrInvalidRequest
+	}
+
+	var params []byte
+	if f.hasParams && !isNullLiteral(f.params) {
+		params = f.params
+	}
+
+	if !f.hasID || isNullLiteral(f.id) {
+		*r = RequestV2{method: method, params: RawMessage(params)}
+		return nil
+	}
+
+	id, idok := decodeID(f.id)
+	if !idok {
+		return ErrInvalidRequest
+	}
+	*r = RequestV2{id: id, method: method, params: RawMessage(params), isCall: true}
+	return nil
 }
 
 // toResponse builds a [*Response] from a response object. A present "error"

--- a/scan.go
+++ b/scan.go
@@ -405,10 +405,14 @@ func scanErrorObject(span []byte, codeSpan, msgSpan, dataSpan *[]byte) (ok bool)
 //
 // The decoder uses a hand-written span scanner: it locates the recognized
 // top-level members without building a map or decoding into a reflection
-// struct, then copies the bytes it needs (id, method, params, result, error)
-// into a single right-sized allocation owned by the returned message. No
-// [RawMessage] in the result aliases data, so the caller may safely reuse or
-// mutate data after the call returns.
+// struct and builds the message from the recorded spans.
+//
+// Lifetime contract (v2): a decoded request's method string and params
+// [RawMessage] BORROW data — they are valid only until data is reused or
+// mutated. Inside a connection the borrow is bounded by "until the handler
+// returns"; a caller that needs the request afterward must copy what it
+// retains (see [RequestV2.Clone] for the concrete request shape). Response
+// results and error members are still copied into owned allocations.
 //
 // A batch (a value whose first non-whitespace byte is '[') is rejected; use
 // [ParseRequests] to handle single-or-batch request input.

--- a/scan.go
+++ b/scan.go
@@ -476,10 +476,11 @@ func (f *fields) toRequest() (Message, error) {
 		return nil, ErrInvalidRequest
 	}
 
-	// R6-A2 spike: the method string and params span are BORROWED from the
-	// scanned frame rather than copied. The borrow is valid until the handler
-	// returns (the read loop does not reuse the frame before then); retention
-	// requires a clone. Owns-bytes tests fail by design while this spike is in.
+	// The method string and params span BORROW the scanned input rather than
+	// copying it; inside a connection the borrow is valid until the handler
+	// returns (the read loop does not reuse the frame before then), and
+	// retention requires a clone. This is the package's documented decode
+	// contract (see DecodeMessage and Handler).
 	method, mok := borrowJSONString(f.method)
 	if !mok {
 		return nil, ErrInvalidRequest
@@ -627,7 +628,11 @@ type ParsedMessage struct {
 // level (neither a single object nor an array of objects). Per-message problems
 // are reported in the Err field of the corresponding [ParsedMessage] rather than
 // failing the whole parse, mirroring the lenient behavior expected of a server
-// front-end. Each parsed message owns its bytes and aliases nothing in data.
+// front-end.
+//
+// Lifetime: each parsed message's method and params BORROW data (escape-bearing
+// strings are decoded into owned copies). They are valid only until data is
+// reused or mutated; copy what you retain. Ids and error members are owned.
 func ParseRequests(data []byte) ([]*ParsedMessage, error) {
 	i := skipSpace(data, 0)
 	if i >= len(data) {

--- a/scan.go
+++ b/scan.go
@@ -411,7 +411,7 @@ func scanErrorObject(span []byte, codeSpan, msgSpan, dataSpan *[]byte) (ok bool)
 // [RawMessage] BORROW data — they are valid only until data is reused or
 // mutated. Inside a connection the borrow is bounded by "until the handler
 // returns"; a caller that needs the request afterward must copy what it
-// retains (see [RequestV2.Clone] for the concrete request shape). Response
+// retains (see [Request.Clone] for the concrete request shape). Response
 // results and error members are still copied into owned allocations.
 //
 // A batch (a value whose first non-whitespace byte is '[') is rejected; use
@@ -504,29 +504,29 @@ func (f *fields) toRequest() (Message, error) {
 	return &Call{id: id, method: method, params: RawMessage(params)}, nil
 }
 
-// scanRequestV2 scans frame as a single JSON-RPC request object directly into
-// a [RequestV2] value, allocating no message box. ok=false routes the frame to
+// scanRequest scans frame as a single JSON-RPC request object directly into
+// a [Request] value, allocating no message box. ok=false routes the frame to
 // the general decode path: responses, batches, and malformed objects all fall
 // through so their error semantics stay identical to [DecodeMessage].
-func scanRequestV2(frame []byte) (rv RequestV2, ok bool) {
+func scanRequest(frame []byte) (rv Request, ok bool) {
 	var f fields
 	end, sok := scanObject(frame, &f)
 	if !sok || skipSpace(frame, end) != len(frame) {
-		return RequestV2{}, false
+		return Request{}, false
 	}
 	if !f.hasMethod || f.hasResult || f.hasError {
-		return RequestV2{}, false
+		return Request{}, false
 	}
-	if f.fillRequestV2(&rv) != nil {
-		return RequestV2{}, false
+	if f.fillRequest(&rv) != nil {
+		return Request{}, false
 	}
 	return rv, true
 }
 
-// fillRequestV2 validates a scanned request object and fills r with borrowed
+// fillRequest validates a scanned request object and fills r with borrowed
 // method and params spans. It mirrors toRequest without the message-box and
 // payload allocations.
-func (f *fields) fillRequestV2(r *RequestV2) error {
+func (f *fields) fillRequest(r *Request) error {
 	if !f.validVersion() {
 		return ErrInvalidRequest
 	}
@@ -542,7 +542,7 @@ func (f *fields) fillRequestV2(r *RequestV2) error {
 	}
 
 	if !f.hasID || isNullLiteral(f.id) {
-		*r = RequestV2{method: method, params: RawMessage(params)}
+		*r = Request{method: method, params: RawMessage(params)}
 		return nil
 	}
 
@@ -550,7 +550,7 @@ func (f *fields) fillRequestV2(r *RequestV2) error {
 	if !idok {
 		return ErrInvalidRequest
 	}
-	*r = RequestV2{id: id, method: method, params: RawMessage(params), isCall: true}
+	*r = Request{id: id, method: method, params: RawMessage(params), isCall: true}
 	return nil
 }
 
@@ -611,7 +611,7 @@ func (f *fields) toResponse() (Message, error) {
 type ParsedMessage struct {
 	// Msg holds the decoded [*Call] or [*Notification] when the message is
 	// well-formed, and is nil when Err is set.
-	Msg Request
+	Msg RequestMessage
 
 	// Err describes why a malformed message could not be decoded, and is nil for
 	// a well-formed message.
@@ -667,7 +667,7 @@ func parseOneRequest(data []byte, batch bool) *ParsedMessage {
 	if err != nil {
 		return &ParsedMessage{Err: ErrInvalidRequest, Batch: batch}
 	}
-	return &ParsedMessage{Msg: msg.(Request), Batch: batch}
+	return &ParsedMessage{Msg: msg.(RequestMessage), Batch: batch}
 }
 
 // scanArrayElements scans a JSON array beginning at data[i] (an opening '[') and

--- a/scan_test.go
+++ b/scan_test.go
@@ -305,25 +305,51 @@ func TestDecodeMessage_OpaqueContainerInterior(t *testing.T) {
 	}
 }
 
-// TestDecodeMessage_OwnsBuffer is the single test guarding pre-mortem #1: the
-// decoded message must not alias the input buffer.
-func TestDecodeMessage_OwnsBuffer(t *testing.T) {
+// TestDecodeMessage_BorrowedLifetime pins the v2 decode contract: a decoded
+// request's method and params BORROW the input buffer (they are valid only as
+// long as the input is unchanged), and the escape hatch for retention is
+// [RequestV2.Clone], which must own its bytes.
+func TestDecodeMessage_BorrowedLifetime(t *testing.T) {
 	t.Parallel()
 
-	in := []byte(`{"jsonrpc":"2.0","method":"m","params":{"k":"value"},"id":1}`)
-	msg, err := DecodeMessage(in)
-	if err != nil {
-		t.Fatalf("DecodeMessage error: %v", err)
+	tests := map[string]struct {
+		wire string
+	}{
+		"success: params borrow the input and Clone owns them": {
+			wire: `{"jsonrpc":"2.0","method":"m","params":{"k":"value"},"id":1}`,
+		},
 	}
-	call := msg.(*Call)
-	before := string(call.Params())
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			in := []byte(tt.wire)
+			msg, err := DecodeMessage(in)
+			if err != nil {
+				t.Fatalf("DecodeMessage error: %v", err)
+			}
+			call := msg.(*Call)
+			before := string(call.Params())
 
-	// Mutate every byte of the input; the decoded params must be unaffected.
-	for i := range in {
-		in[i] = 'Z'
-	}
-	if string(call.Params()) != before {
-		t.Errorf("params aliased input buffer: got %q, want %q", call.Params(), before)
+			rv, ok := scanRequestV2(in)
+			if !ok {
+				t.Fatalf("scanRequestV2 rejected a valid request")
+			}
+			owned := rv.Clone()
+
+			// Mutate every byte of the input. The borrowed views must observe the
+			// mutation (aliasing IS the contract), while the clone must not.
+			for i := range in {
+				in[i] = 'Z'
+			}
+			if string(call.Params()) == before {
+				t.Errorf("decoded params did not alias the input buffer; the borrowed-lifetime contract expects aliasing")
+			}
+			if got := string(owned.Params()); got != before {
+				t.Errorf("Clone().Params() = %q, want owned copy %q after input mutation", got, before)
+			}
+			if owned.Method() != "m" {
+				t.Errorf("Clone().Method() = %q, want %q after input mutation", owned.Method(), "m")
+			}
+		})
 	}
 }
 

--- a/scan_test.go
+++ b/scan_test.go
@@ -6,6 +6,7 @@ package jsonrpc2
 import (
 	"bytes"
 	stdjson "encoding/json"
+	"strings"
 	"testing"
 	"unicode/utf8"
 
@@ -348,6 +349,46 @@ func TestDecodeMessage_BorrowedLifetime(t *testing.T) {
 			}
 			if owned.Method() != "m" {
 				t.Errorf("Clone().Method() = %q, want %q after input mutation", owned.Method(), "m")
+			}
+		})
+	}
+}
+
+// TestParseRequests_BorrowedLifetime pins ParseRequests' documented borrow:
+// parsed methods and params alias data and die with it, and copying before
+// reuse is the retention pattern.
+func TestParseRequests_BorrowedLifetime(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		wire string
+	}{
+		"success: parsed members borrow the input": {
+			wire: `[{"jsonrpc":"2.0","id":1,"method":"alpha","params":{"k":"v"}},{"jsonrpc":"2.0","method":"beta"}]`,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			in := []byte(tt.wire)
+			parsed, err := ParseRequests(in)
+			if err != nil {
+				t.Fatalf("ParseRequests: %v", err)
+			}
+			if len(parsed) != 2 || parsed[0].Err != nil || parsed[1].Err != nil {
+				t.Fatalf("ParseRequests = %+v, want two valid members", parsed)
+			}
+			ownedMethod := strings.Clone(parsed[0].Msg.Method())
+			ownedParams := string(parsed[0].Msg.Params())
+
+			for i := range in {
+				in[i] = 'Z'
+			}
+
+			if got := parsed[0].Msg.Method(); got == "alpha" {
+				t.Errorf("parsed method still reads %q after input mutation; the documented contract is a borrow", got)
+			}
+			if ownedMethod != "alpha" || ownedParams != `{"k":"v"}` {
+				t.Errorf("owned copies = (%q, %q), want (alpha, {\"k\":\"v\"}); copying before reuse must preserve the data", ownedMethod, ownedParams)
 			}
 		})
 	}

--- a/scan_test.go
+++ b/scan_test.go
@@ -308,7 +308,7 @@ func TestDecodeMessage_OpaqueContainerInterior(t *testing.T) {
 // TestDecodeMessage_BorrowedLifetime pins the v2 decode contract: a decoded
 // request's method and params BORROW the input buffer (they are valid only as
 // long as the input is unchanged), and the escape hatch for retention is
-// [RequestV2.Clone], which must own its bytes.
+// [Request.Clone], which must own its bytes.
 func TestDecodeMessage_BorrowedLifetime(t *testing.T) {
 	t.Parallel()
 
@@ -329,9 +329,9 @@ func TestDecodeMessage_BorrowedLifetime(t *testing.T) {
 			call := msg.(*Call)
 			before := string(call.Params())
 
-			rv, ok := scanRequestV2(in)
+			rv, ok := scanRequest(in)
 			if !ok {
-				t.Fatalf("scanRequestV2 rejected a valid request")
+				t.Fatalf("scanRequest rejected a valid request")
 			}
 			owned := rv.Clone()
 
@@ -863,7 +863,7 @@ func compactJSON(b []byte) ([]byte, error) {
 //   - batch.go invalidRequest.Method/Params: a synthetic placeholder for a
 //     malformed batch member that is always answered with a null-id error before
 //     the user handler runs, so these accessors are never invoked on the dispatch
-//     path; they exist only to satisfy the [Request] interface.
+//     path; they exist only to satisfy the [RequestMessage] interface.
 //   - conn.go / dispatch.go write-error and shutdown-race arms: the branches that
 //     fire when the writer breaks mid-response or the connection is torn down
 //     between checks. These are timing-dependent and are exercised by the race

--- a/scan_test.go
+++ b/scan_test.go
@@ -810,7 +810,7 @@ func compactJSON(b []byte) ([]byte, error) {
 	return dst.Bytes(), nil
 }
 
-// Scanner / dispatch coverage gap review (AC-C5).
+// Scanner / dispatch coverage gap review.
 //
 // Package coverage is >= 90% of statements. The few statements that remain
 // uncovered are concentrated in the hand-written scanner and the dispatch state

--- a/serve_test.go
+++ b/serve_test.go
@@ -28,15 +28,21 @@ func echoHandler(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Reque
 
 // dialConn dials addr on network and returns a client [jsonrpc2.Conn] over the
 // LSP header framing that the server uses, together with the underlying net.Conn
-// so the caller can close it.
+// so the caller can close it. It retries briefly so a test does not race a
+// server that binds its listener asynchronously (such as ListenAndServe).
 func dialConn(t *testing.T, network, addr string) (jsonrpc2.Conn, net.Conn) {
 	t.Helper()
-	nc, err := net.DialTimeout(network, addr, 5*time.Second)
-	if err != nil {
-		t.Fatalf("dial %s %s: %v", network, addr, err)
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		nc, err := net.DialTimeout(network, addr, time.Second)
+		if err == nil {
+			return jsonrpc2.NewConn(jsonrpc2.NewStream(nc)), nc
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("dial %s %s: %v", network, addr, err)
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
-	conn := jsonrpc2.NewConn(jsonrpc2.NewStream(nc))
-	return conn, nc
 }
 
 // TestServeRoundTrip exercises the gopls-style serving surface end to end over a

--- a/serve_test.go
+++ b/serve_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net"
 	"runtime"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -17,13 +18,18 @@ import (
 	"go.lsp.dev/jsonrpc2"
 )
 
-// echoHandler replies to "echo" calls with their params and drops everything
-// else with a method-not-found error.
-func echoHandler(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+// echoHandler answers "echo" calls with a copy of their borrowed params,
+// rejects other calls with a method-not-found error, and drops notifications.
+func echoHandler(ctx context.Context, req *jsonrpc2.Request) (any, error) {
 	if req.Method() == "echo" {
-		return reply(ctx, req.Params(), nil)
+		// The params bytes are only valid until the handler returns; clone them
+		// since the returned result is marshaled afterward.
+		return slices.Clone(req.Params()), nil
 	}
-	return reply(ctx, nil, jsonrpc2.ErrMethodNotFound)
+	if !req.IsCall() {
+		return nil, nil
+	}
+	return nil, jsonrpc2.ErrMethodNotFound
 }
 
 // dialConn dials addr on network and returns a client [jsonrpc2.Conn] over the

--- a/syncclient_test.go
+++ b/syncclient_test.go
@@ -26,14 +26,14 @@ func syncClientServer(t *testing.T, framer Framer) (*SyncClient, func()) {
 	}
 	server := NewConn(framer(cb))
 	ctx := t.Context()
-	server.Go(ctx, func(ctx context.Context, reply Replier, req Request) error {
+	server.Go(ctx, func(ctx context.Context, req *Request) (any, error) {
 		switch req.Method() {
 		case "echo":
-			return reply(ctx, raw(`{"got":`+string(orNull(req.Params()))+`}`), nil)
+			return raw(`{"got":` + string(orNull(req.Params())) + `}`), nil
 		case "fail":
-			return reply(ctx, nil, NewError(InvalidParams, "bad params"))
+			return nil, NewError(InvalidParams, "bad params")
 		default:
-			return reply(ctx, nil, nil)
+			return nil, nil
 		}
 	})
 	cleanup := func() {
@@ -117,15 +117,14 @@ func TestSyncClientNotifyThenCall(t *testing.T) {
 	var seen string
 	var seenMu sync.Mutex
 	serverCtx := t.Context()
-	server.Go(serverCtx, func(ctx context.Context, reply Replier, req Request) error {
+	server.Go(serverCtx, func(ctx context.Context, req *Request) (any, error) {
 		if req.Method() == "note" {
 			seenMu.Lock()
 			seen = string(orNull(req.Params()))
 			seenMu.Unlock()
 			notes.Done()
-			return reply(ctx, nil, nil)
 		}
-		return reply(ctx, nil, nil)
+		return nil, nil
 	})
 	defer func() {
 		_ = client.Close()
@@ -176,8 +175,8 @@ func TestSyncClientEquivalentToConn(t *testing.T) {
 	server := NewConn(NewNDJSONStream(cb))
 	connCtx := t.Context()
 	cc.Go(connCtx, MethodNotFoundHandler)
-	server.Go(connCtx, func(ctx context.Context, reply Replier, req Request) error {
-		return reply(ctx, raw(`{"got":`+string(orNull(req.Params()))+`}`), nil)
+	server.Go(connCtx, func(ctx context.Context, req *Request) (any, error) {
+		return raw(`{"got":` + string(orNull(req.Params())) + `}`), nil
 	})
 	defer func() {
 		_ = cc.Close()

--- a/view.go
+++ b/view.go
@@ -173,8 +173,9 @@ type ParsedMessageView struct {
 // ScanRequestViews parses a single request or a batch of requests into borrowed
 // views.
 //
-// It mirrors [ParseRequests] but does not build owned [Call] or [Notification]
-// values. The returned views alias data and must not outlive the current
+// It mirrors [ParseRequests] but yields flat span views instead of boxed
+// [Call] or [Notification] messages (whose method and params likewise borrow
+// data). The returned views alias data and must not outlive the current
 // frame/callback lifetime unless cloned or converted to owned messages.
 func ScanRequestViews(data []byte) ([]ParsedMessageView, error) {
 	return AppendRequestViews(nil, data)

--- a/view_test.go
+++ b/view_test.go
@@ -68,7 +68,7 @@ func TestScanMessageView_DifferentialCorpus(t *testing.T) {
 
 	// FuzzScan in scan_test.go differentially checks DecodeMessage against an
 	// encoding/json oracle. This corpus ties the borrowed view scanner to that
-	// owned scanner over the benchmark shapes that matter for AC-C5: escaped
+	// owned scanner over the shapes the scanner must get right: escaped
 	// strings, duplicate fields, malformed inputs, batches, and large payloads.
 	type testCase struct {
 		name  string


### PR DESCRIPTION
## Summary

This PR lands the JSON-RPC hot-path optimization work on the `perf` branch. It consolidates request dispatch around the direct-return handler API, removes the reply-closure machinery, and tightens the frame/message ownership contracts so the common request/response paths avoid unnecessary allocations.

Key changes:

- Make `Handler` return `(any, error)` directly and route `Conn.Go`, batch dispatch, preemption, and fallback stream handling through that single surface.
- Introduce pooled concrete request/frame paths with explicit borrowed-lifetime documentation and `Request.Clone` guidance for retained data.
- Move channel streams to pooled frame ownership handoff instead of clone-on-queue, preserving immediate caller buffer reuse for `WriteFrame` while reducing steady-state transport allocations.
- Classify incoming frames with a single scan and reuse parsed spans for request filling and response delivery.
- Add focused direct-dispatch, poison-build, scan, liveness, and compatibility coverage for the new ownership and API contracts.
- Update the benchmark ledger with current darwin/arm64 and linux/amd64 evidence, rejected alternatives, and the remaining known tradeoffs.

## Why

The previous API required per-request reply plumbing even for the synchronous common case. That structure forced avoidable heap objects in the hot path and made several lower-level optimizations harder to express safely. The new direct-return shape makes the response value the handler return value, which is simpler for callers and gives the implementation a single dispatch path to optimize.

## Impact

### User-facing/API impact

- `Handler` implementations now return `(any, error)` instead of replying through a `Replier` callback.
- Request method/params are borrowed from the current transport frame during handler execution. Callers that retain request data after the handler returns must clone it.
- A handler that returns zero values now sends a successful `null` result. The old "returned without replying" internal-error state no longer exists because direct-return handlers always define the reply.

### Performance impact

The benchmark ledger records the final optimization gate and refresh evidence. Highlights include:

- Root `BenchmarkVoidRoundTrip`: `0 B/op`, `0 allocs/op` in the recorded final gate.
- Native/common `Notify`: `0 B/op`, `0 allocs/op` in both families.
- Large-params and batch rows materially reduce allocation pressure and improve latency in the documented rows.
- The one disclosed cost is the high-depth pipelined writer-convoy row; it is documented because the viable fix class was rejected earlier on design constraints.

## Validation

Fresh local validation before opening this PR:

```text
$ git diff --check origin/main..HEAD
# clean

$ go test ./...
ok   go.lsp.dev/jsonrpc2                  0.480s
?    go.lsp.dev/jsonrpc2/conformance      [no test files]
ok   go.lsp.dev/jsonrpc2/examples/batch   0.011s
ok   go.lsp.dev/jsonrpc2/examples/peer    0.012s
ok   go.lsp.dev/jsonrpc2/examples/serve   0.011s
```


Follow-up validation after the CI lint fix commit (`398249f`):

```text
$ make lint
0 issues.

$ go test ./...
ok   go.lsp.dev/jsonrpc2                  0.475s
?    go.lsp.dev/jsonrpc2/conformance      [no test files]
ok   go.lsp.dev/jsonrpc2/examples/batch   (cached)
ok   go.lsp.dev/jsonrpc2/examples/peer    (cached)
ok   go.lsp.dev/jsonrpc2/examples/serve   (cached)

$ git diff --check
# clean
```

The benchmark ledger also documents earlier correctness gates for this branch, including race runs, conformance vectors, fuzz runs, poison-build retention tests, vet/gopls checks, internal benchmark tests, and linux/amd64 confirmation for the current optimization floor.

## Review notes

This is intentionally a large performance/API PR. Suggested review order:

1. Read `handler.go`, `conn.go`, and `dispatch.go` for the direct-return API and dispatch contract.
2. Read `message.go`, `scan.go`, and `jsonstr.go` for borrowed request data and frame classification.
3. Read `channel_stream.go` for pooled frame ownership handoff.
4. Read `dispatch_direct_test.go`, `poison_test.go`, and the updated compatibility/robustness tests for contract coverage.
5. Use `internal/benchmark/RESULTS.md` as the performance ledger and rejected-alternatives record.

