### PR TITLE
Clean up raw copies and test diagnostics

### DIFF
--- a/codec/goccy/raw.go
+++ b/codec/goccy/raw.go
@@ -5,6 +5,7 @@ package goccy
 
 import (
 	stdjson "encoding/json"
+	"slices"
 
 	"go.lsp.dev/jsonrpc2"
 )
@@ -38,22 +39,12 @@ func rawMarshal(raw []byte) []byte {
 func rawUnmarshal(data []byte, v any) (handled bool) {
 	switch p := v.(type) {
 	case *jsonrpc2.RawMessage:
-		*p = cloneBytes(data)
+		*p = slices.Clone(data)
 		return true
 	case *stdjson.RawMessage:
-		*p = cloneBytes(data)
+		*p = slices.Clone(data)
 		return true
 	default:
 		return false
 	}
-}
-
-// cloneBytes returns a right-sized copy of src, preserving nilness.
-func cloneBytes(src []byte) []byte {
-	if src == nil {
-		return nil
-	}
-	dst := make([]byte, len(src))
-	copy(dst, src)
-	return dst
 }

--- a/codec/sonic/raw.go
+++ b/codec/sonic/raw.go
@@ -5,6 +5,7 @@ package sonic
 
 import (
 	stdjson "encoding/json"
+	"slices"
 
 	"go.lsp.dev/jsonrpc2"
 )
@@ -38,22 +39,12 @@ func rawMarshal(raw []byte) []byte {
 func rawUnmarshal(data []byte, v any) (handled bool) {
 	switch p := v.(type) {
 	case *jsonrpc2.RawMessage:
-		*p = cloneBytes(data)
+		*p = slices.Clone(data)
 		return true
 	case *stdjson.RawMessage:
-		*p = cloneBytes(data)
+		*p = slices.Clone(data)
 		return true
 	default:
 		return false
 	}
-}
-
-// cloneBytes returns a right-sized copy of src, preserving nilness.
-func cloneBytes(src []byte) []byte {
-	if src == nil {
-		return nil
-	}
-	dst := make([]byte, len(src))
-	copy(dst, src)
-	return dst
 }

--- a/compat_test.go
+++ b/compat_test.go
@@ -56,6 +56,26 @@ func (m methodMap) handler(ctx context.Context, req *jsonrpc2.Request) (any, err
 	return fn(ctx, req.Params())
 }
 
+func serveCompat(t *testing.T, ctx context.Context, ln net.Listener, server jsonrpc2.StreamServer) {
+	t.Helper()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- jsonrpc2.Serve(ctx, ln, server, 0)
+	}()
+
+	t.Cleanup(func() {
+		select {
+		case err := <-serveErr:
+			if !errors.Is(err, context.Canceled) && !errors.Is(err, net.ErrClosed) {
+				t.Errorf("Serve returned %v, want context cancellation", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Error("Serve did not exit after test context cancellation")
+		}
+	})
+}
+
 // TestDownstreamCompatShim proves the gopls-style usage compiles and round-trips
 // typed params/results through the default codec over a real network listener.
 func TestDownstreamCompatShim(t *testing.T) {
@@ -92,7 +112,7 @@ func TestDownstreamCompatShim(t *testing.T) {
 	}
 
 	server := jsonrpc2.HandlerServer(mm.handler)
-	go func() { _ = jsonrpc2.Serve(ctx, ln, server, 0) }()
+	serveCompat(t, ctx, ln, server)
 
 	client, nc := dialConn(t, "tcp", ln.Addr().String())
 	defer nc.Close()
@@ -172,7 +192,7 @@ func TestDownstreamNotify(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	go func() { _ = jsonrpc2.Serve(ctx, ln, server, 0) }()
+	serveCompat(t, ctx, ln, server)
 
 	client, nc := dialConn(t, "tcp", ln.Addr().String())
 	defer nc.Close()
@@ -241,7 +261,7 @@ func TestDownstreamCancel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	go func() { _ = jsonrpc2.Serve(ctx, ln, server, 0) }()
+	serveCompat(t, ctx, ln, server)
 
 	client, nc := dialConn(t, "tcp", ln.Addr().String())
 	defer nc.Close()

--- a/compat_test.go
+++ b/compat_test.go
@@ -65,6 +65,7 @@ func serveCompat(t *testing.T, ctx context.Context, ln net.Listener, server json
 	}()
 
 	t.Cleanup(func() {
+		_ = ln.Close()
 		select {
 		case err := <-serveErr:
 			if !errors.Is(err, context.Canceled) && !errors.Is(err, net.ErrClosed) {

--- a/dispatch_direct_test.go
+++ b/dispatch_direct_test.go
@@ -302,7 +302,7 @@ func TestPooledRequestFieldReset(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ir := getIncomingRequest()
-			ir.parent = context.Background()
+			ir.parent = t.Context()
 			ir.id = NewNumberID(7)
 			ir.isCall = true
 			ir.canceled = true

--- a/pipeline_client_test.go
+++ b/pipeline_client_test.go
@@ -16,26 +16,25 @@ import (
 func TestScanPipelineResultResponseNumber(t *testing.T) {
 	t.Parallel()
 
-	for _, tt := range []struct {
-		name   string
+	tests := map[string]struct {
 		frame  string
 		id     int64
 		result string
 	}{
-		{
-			name:   "object",
+		"success: object result": {
 			frame:  `{"jsonrpc":"2.0","id":42,"result":{"ok":true}}`,
 			id:     42,
 			result: `{"ok":true}`,
 		},
-		{
-			name:   "null",
+		"success: null result": {
 			frame:  `{"jsonrpc":"2.0","id":43,"result":null}`,
 			id:     43,
 			result: `null`,
 		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
 			id, result, ok, err := scanPipelineResultResponseNumber([]byte(tt.frame))
@@ -58,30 +57,62 @@ func TestScanPipelineResultResponseNumber(t *testing.T) {
 func TestScanPipelineResultResponseNumberFallbacks(t *testing.T) {
 	t.Parallel()
 
-	for _, frame := range [][]byte{
-		[]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"missing"}}`),
-		[]byte(`{"jsonrpc":"2.0","id":0,"result":null}`),
-		[]byte(`{"jsonrpc":"2.0","id":"1","result":null}`),
-		[]byte(`{"jsonrpc":"2.0","id":9223372036854775808,"result":null}`),
-		[]byte(`{"id":1,"jsonrpc":"2.0","result":null}`),
-		[]byte(`[{"jsonrpc":"2.0","id":1,"result":null}]`),
-	} {
-		if _, _, ok, err := scanPipelineResultResponseNumber(frame); ok || err != nil {
-			t.Fatalf("scanPipelineResultResponseNumber(%q) = ok %v, err %v; want fallback", frame, ok, err)
-		}
+	tests := map[string]struct {
+		frame []byte
+	}{
+		"fallback: error response": {
+			frame: []byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"missing"}}`),
+		},
+		"fallback: zero id": {
+			frame: []byte(`{"jsonrpc":"2.0","id":0,"result":null}`),
+		},
+		"fallback: string id": {
+			frame: []byte(`{"jsonrpc":"2.0","id":"1","result":null}`),
+		},
+		"fallback: id overflow": {
+			frame: []byte(`{"jsonrpc":"2.0","id":9223372036854775808,"result":null}`),
+		},
+		"fallback: field order mismatch": {
+			frame: []byte(`{"id":1,"jsonrpc":"2.0","result":null}`),
+		},
+		"fallback: batch array": {
+			frame: []byte(`[{"jsonrpc":"2.0","id":1,"result":null}]`),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if _, _, ok, err := scanPipelineResultResponseNumber(tt.frame); ok || err != nil {
+				t.Fatalf("scanPipelineResultResponseNumber(%q) = ok %v, err %v; want fallback", tt.frame, ok, err)
+			}
+		})
 	}
 }
 
 func TestScanPipelineResultResponseNumberInvalid(t *testing.T) {
 	t.Parallel()
 
-	for _, frame := range [][]byte{
-		[]byte(`{"jsonrpc":"2.0","id":1,"result":`),
-		[]byte(`{"jsonrpc":"2.0","id":1,"result":null} trailing`),
-	} {
-		if _, _, ok, err := scanPipelineResultResponseNumber(frame); ok || err == nil {
-			t.Fatalf("scanPipelineResultResponseNumber(%q) = ok %v, err %v; want invalid/parse", frame, ok, err)
-		}
+	tests := map[string]struct {
+		frame []byte
+	}{
+		"error: missing result value": {
+			frame: []byte(`{"jsonrpc":"2.0","id":1,"result":`),
+		},
+		"error: trailing data": {
+			frame: []byte(`{"jsonrpc":"2.0","id":1,"result":null} trailing`),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if _, _, ok, err := scanPipelineResultResponseNumber(tt.frame); ok || err == nil {
+				t.Fatalf("scanPipelineResultResponseNumber(%q) = ok %v, err %v; want invalid/parse", tt.frame, ok, err)
+			}
+		})
 	}
 }
 

--- a/pool.go
+++ b/pool.go
@@ -3,7 +3,10 @@
 
 package jsonrpc2
 
-import "sync"
+import (
+	"slices"
+	"sync"
+)
 
 // encodeBufInitCap is the initial capacity of a pooled encode buffer. It is
 // sized to hold a typical small envelope without a reallocation.
@@ -43,12 +46,7 @@ func putEncodeBuf(bp *[]byte) {
 // nil src yields a nil result so that "absent" stays distinguishable from
 // "present but empty".
 func cloneBytes(src []byte) []byte {
-	if src == nil {
-		return nil
-	}
-	dst := make([]byte, len(src))
-	copy(dst, src)
-	return dst
+	return slices.Clone(src)
 }
 
 // irPool recycles incomingRequest structs across the direct-return dispatch


### PR DESCRIPTION
## Summary

This PR applies a narrow anti-slop cleanup pass over the JSON-RPC module while preserving behavior.

It removes bespoke byte-copy loops in favor of the Go 1.26 standard-library helper, and it improves test diagnostics around downstream serving compatibility and pipeline scanner fallback behavior.

## What changed

- Replace local raw-byte copy loops with `slices.Clone` in:
  - `pool.go`
  - `codec/goccy/raw.go`
  - `codec/sonic/raw.go`
- Check downstream compatibility server shutdown errors instead of discarding them in background goroutines.
- Use `t.Context()` in the pooled-request reset test instead of a global background context.
- Convert pipeline response scanner table tests to named map cases so failures identify the exact preserved path.

## Why

The code already behaved correctly, but a few cleanup smells reduced review signal:

- small duplicated byte-copy helpers obscured the nil-preserving copy intent;
- downstream compatibility tests ignored `Serve` errors from helper goroutines;
- scanner fallback tests used anonymous cases, making failures less precise.

The cleanup keeps compatibility/performance fallback paths intact. A broader internal helper extraction for codec raw-message passthrough was intentionally avoided because the nested codec modules need to keep working under the repository's default vendor-mode behavior.

## Impact

- No public API changes.
- No dependency changes.
- Raw-message copy semantics remain nil-preserving.
- Test failures should be easier to diagnose when serve shutdown or scanner fallback behavior regresses.

## Validation

- `go test ./...`
- `(cd codec/goccy && go test ./...)`
- `(cd codec/sonic && go test ./...)`
- `(cd internal/benchmark && go test ./...)`
- `go test -race -count=1 ./...`
- `(cd codec/goccy && go test -race -count=1 ./...)`
- `(cd codec/sonic && go test -race -count=1 ./...)`
- `(cd internal/benchmark && go test -race -count=1 ./...)`
- `go vet ./...` across root and nested modules
- `golangci-lint run --config .golangci.yaml ./...`
- `gofmt` / `gofumpt -extra`

## Notes

`go tool modernize -fix -test ./...` was attempted, but this Go toolchain does not provide a `modernize` tool. The directly relevant modernization (`slices.Clone`) was applied manually and covered by the checks above.
